### PR TITLE
add info in readme; add git ownership excemption in dev container

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -34,7 +34,8 @@
 	},
 	"remoteEnv": {
 		"PATH": "${containerEnv:VIRTUAL_ENV}/bin:${containerEnv:PATH}",
-	}
+	},
+	"postStartCommand": "git config --global --add safe.directory ${containerWorkspaceFolder}"
 	// Use 'postCreateCommand' to run commands after the container is created.
 	// "postCreateCommand": "pip install --user -r requirements.txt",
 	// Configure tool-specific properties.

--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@ geo libraries for postgis and geodjango are required to be installed
 - No support for XML
 - If multiple of the same criteria are specified, the last specified will be used (not a 400 response)
 - /results
-    - positionText no longer has "N" as a possible value, "R" is used instead. 
-    - The Time.time key will always 3 digits after decimal points (using trailing zeros). 
+    - positionText no longer has "N" as a possible value, "R" is used instead.
+    - The Time.time key will always 3 digits after decimal points (using trailing zeros).
     - Time.time is generated from Time.millis so they will now always be consistent.
 - Standings position is based on total points scored instead of championship points rules (only effects seasons before 1991)
 - Standings requires a year to be specified
@@ -26,12 +26,16 @@ Fun Facts
 ### Prerequisite
 Use of the devcontainer is recommended. If not using, look at `.devcontainer/Dockerfile` for required installs.<br>
 Current requirements are:
-- Poetry for python 
+- Poetry for python
 - [Geo Libraries for postgis and geodjango](https://docs.djangoproject.com/en/4.2/ref/contrib/gis/install/geolibs/#geosbuild)
 - A postgres database which can be accessed via the `DATABASE_SECRET_URL` environment variable.
 
 ### Data Import
 - If not using the devcontainer, Install python dependencies `poetry install`, and activate the venv `poetry shell`
+- Create all required database tables
+  ```
+  python manage.py migrate
+  ```
 - Download csv data from ergast and import into postgres database
   ```
   make load-ergast-data
@@ -47,5 +51,5 @@ This will fill the database with the latest data from ergast, and create the ini
 The first time the tests are run it will take upto 2 minutes to populate the database with test data, pytest is configured to reuse this database on future runs, so tests should run much faster on future runs.<br>
 To run tests after a migration change you must run with the `--create-db` flag to ensure it uses the new migrations.<br>
 
-To run the tests 
+To run the tests
 ```pytest```


### PR DESCRIPTION
- Adds info to run migrate first so that all tables are created. Else, the following command will fail. (I think this is right?)

- Adds an exemption from the git ownership check to the git configuration of the container (not the host). This prevents an error due to "dubious ownership" in the container that prevents you from using git because the directory in the container and the repository are owned by different users. This is caused by how docker mounts files in the container.