### PR TITLE
fix URL routing for HTML view

### DIFF
--- a/jolpica_api/ergastapi/urls.py
+++ b/jolpica_api/ergastapi/urls.py
@@ -42,19 +42,19 @@ router.register("constructor[sS]tandings", views.ConstructorStandingViewSet, bas
 
 
 criteria = [
-    r"(circuits/(?P<circuit_ref>[a-zA-Z0-9_\-]+)/)(?!$)",
-    r"(constructors/(?P<team_ref>[a-zA-Z0-9_\-]+)/)(?!$)",
-    r"(drivers/(?P<driver_ref>[a-zA-Z0-9_\-]+)/)(?!$)",
-    r"(grid/(?P<grid_position>[a-zA-Z0-9_\-]+)/)(?!$)",
-    r"(results/(?P<race_position>[a-zA-Z0-9_\-]+)/)(?!$)",
-    r"(fastest/(?P<fastest_lap_rank>[a-zA-Z0-9_\-]+)/)(?!$)",
-    r"(status/(?P<ergast_status_id>[a-zA-Z0-9_\-]+)/)(?!$)",
-    r"(laps/(?P<lap_number>[a-zA-Z0-9_\-]+)/)(?!$)",
+    r"(circuits/(?P<circuit_ref>[a-zA-Z0-9_\-]+)/)",
+    r"(constructors/(?P<team_ref>[a-zA-Z0-9_\-]+)/)",
+    r"(drivers/(?P<driver_ref>[a-zA-Z0-9_\-]+)/)",
+    r"(grid/(?P<grid_position>[a-zA-Z0-9_\-]+)/)",
+    r"(results/(?P<race_position>[a-zA-Z0-9_\-]+)/)",
+    r"(fastest/(?P<fastest_lap_rank>[a-zA-Z0-9_\-]+)/)",
+    r"(status/(?P<ergast_status_id>[a-zA-Z0-9_\-]+)/)",
+    r"(laps/(?P<lap_number>[a-zA-Z0-9_\-]+)/)",
 ]
 season_criteria = r"(?P<season_year>[0-9]{4}|current)"
 round_criteria = r"(?P<race_round>[0-9]{1,2}|next|last)"
 season_round_criteria = f"({season_criteria}/({round_criteria}/)?)?"
-regex_criteria = season_round_criteria + f"({'|'.join(criteria)})*"
+regex_criteria = season_round_criteria + f"({'|'.join(criteria)})*" + r"(?!$)"
 
 
 class RaceRouter(routers.DefaultRouter):

--- a/jolpica_api/ergastapi/urls.py
+++ b/jolpica_api/ergastapi/urls.py
@@ -42,14 +42,14 @@ router.register("constructor[sS]tandings", views.ConstructorStandingViewSet, bas
 
 
 criteria = [
-    r"(circuits/(?P<circuit_ref>[a-zA-Z0-9_\-]+)/)",
-    r"(constructors/(?P<team_ref>[a-zA-Z0-9_\-]+)/)",
-    r"(drivers/(?P<driver_ref>[a-zA-Z0-9_\-]+)/)",
-    r"(grid/(?P<grid_position>[a-zA-Z0-9_\-]+)/)",
-    r"(results/(?P<race_position>[a-zA-Z0-9_\-]+)/)",
-    r"(fastest/(?P<fastest_lap_rank>[a-zA-Z0-9_\-]+)/)",
-    r"(status/(?P<ergast_status_id>[a-zA-Z0-9_\-]+)/)",
-    r"(laps/(?P<lap_number>[a-zA-Z0-9_\-]+)/)",
+    r"(circuits/(?P<circuit_ref>[a-zA-Z0-9_\-]+)/)(?!$)",
+    r"(constructors/(?P<team_ref>[a-zA-Z0-9_\-]+)/)(?!$)",
+    r"(drivers/(?P<driver_ref>[a-zA-Z0-9_\-]+)/)(?!$)",
+    r"(grid/(?P<grid_position>[a-zA-Z0-9_\-]+)/)(?!$)",
+    r"(results/(?P<race_position>[a-zA-Z0-9_\-]+)/)(?!$)",
+    r"(fastest/(?P<fastest_lap_rank>[a-zA-Z0-9_\-]+)/)(?!$)",
+    r"(status/(?P<ergast_status_id>[a-zA-Z0-9_\-]+)/)(?!$)",
+    r"(laps/(?P<lap_number>[a-zA-Z0-9_\-]+)/)(?!$)",
 ]
 season_criteria = r"(?P<season_year>[0-9]{4}|current)"
 round_criteria = r"(?P<race_round>[0-9]{1,2}|next|last)"


### PR DESCRIPTION
## Why are you making this change?

Fix #50 

Note that the problem is not specific to the ``/circuits`` endpoint but it is relevant for all endpoints that can also be used as filters.

Example endpoints that are currently broken as HTML but work as JSON:

- http://api.jolpi.ca/ergast/f1/circuits/monza vs http://api.jolpi.ca/ergast/f1/circuits/monza.json
- http://api.jolpi.ca/ergast/f1/constructors/ferrari vs http://api.jolpi.ca/ergast/f1/constructors/ferrari.json 

Solution: add negative lookahead to prevent matching the criteria at the very end of the endpoint path. This ensures that any of the criteria regex strings is NOT matched as filter parameter when it is the end of the endpoint path. Currently, the router matches the end of the string as a filter parameter as well and then fails to determine the actual endpoint because the full path has been "matched away".

One remaining difference is that this still redirect ``.../circuits/monza`` to ``.../circuits/monza/`` with a 301 response, adding the trailing slash. But only the endpoint without trailing slash is valid in Ergast. I'd say this is irrelevant, because the HTML interface is only used through a browser by humans and this will not cause any problems.

## Contributing Checklist
- [x] Unit tests for the changes are included in this PR.
- [x] I have read and agreed to the [contributing guidelines](CONTRIBUTING.md).
