### PR TITLE
Fix incorrect type hints in to_representation signature

### DIFF
--- a/jolpica_api/ergastapi/serializers.py
+++ b/jolpica_api/ergastapi/serializers.py
@@ -165,7 +165,7 @@ class DriverSerializer(ErgastModelSerializer):
 
 
 class ListResultsSerializer(serializers.ListSerializer):
-    def to_representation(self, data: QuerySet[SessionEntry]) -> Any:
+    def to_representation(self, data: list[SessionEntry]) -> Any:
         is_single = False
         is_qualifying = self.child.results_list_name == "QualifyingResults"
         if isinstance(data, SessionEntry):
@@ -281,7 +281,7 @@ class SprintResultsSerializer(RaceResultsSerializer):
 
 
 class ListQualifyingSerializer(serializers.ListSerializer):
-    def to_representation(self, round_entries: QuerySet[RoundEntry]) -> Any:
+    def to_representation(self, round_entries: list[RoundEntry]) -> Any:
         is_single = False
         if isinstance(round_entries, RoundEntry):
             round_entries = (
@@ -350,7 +350,7 @@ class QualifyingResultsSerializer(ErgastModelSerializer):
 
 
 class ListPitStopSerializer(serializers.ListSerializer):
-    def to_representation(self, pit_stops: QuerySet[PitStop]) -> Any:
+    def to_representation(self, pit_stops: list[PitStop]) -> Any:
         is_single = False
         if isinstance(pit_stops, PitStop):
             pit_stops = (
@@ -399,7 +399,7 @@ class PitStopSerializer(ErgastModelSerializer):
 
 
 class ListLapSerializer(serializers.ListSerializer):
-    def to_representation(self, laps: QuerySet[Lap]) -> Any:
+    def to_representation(self, laps: list[Lap]) -> Any:
         is_single = False
         if isinstance(laps, Lap):
             laps = Lap.objects.filter(pk=laps.pk).select_related("session_entry__round_entry__round").distinct()


### PR DESCRIPTION
## Why are you making this change?

Type hints in the signature are incorrect.

As per https://github.com/encode/django-rest-framework/blob/fe92f0dd0d4c587eed000c7de611ddbff241bd6a/rest_framework/serializers.py#L707 and manual verification at runtime, ``ListSerializer.to_representation()`` takes a list of instances, not a query set. 


## Contributing Checklist
- [ ] Unit tests for the changes are included in this PR.
- [x] I have read and agreed to the [contributing guidelines](CONTRIBUTING.md).
