### PR TITLE
Fix Invalid type ASGIRequest error message

### DIFF
--- a/jolpica_api/logging.py
+++ b/jolpica_api/logging.py
@@ -1,9 +1,10 @@
 import logging
 import logging.config
 
+from django.http.request import HttpRequest
 from gunicorn import glogging
 from opentelemetry.exporter.otlp.proto.grpc._log_exporter import OTLPLogExporter
-from opentelemetry.sdk._logs import LoggerProvider
+from opentelemetry.sdk._logs import LoggerProvider, LoggingHandler
 from opentelemetry.sdk._logs.export import BatchLogRecordProcessor
 
 # Authenticates with the OTEL_EXPORTER_OTLP_HEADERS environment variable
@@ -11,6 +12,23 @@ from opentelemetry.sdk._logs.export import BatchLogRecordProcessor
 logger_provider = LoggerProvider()
 exporter = OTLPLogExporter()
 logger_provider.add_log_record_processor(BatchLogRecordProcessor(exporter))
+
+
+class CustomLoggingHandler(LoggingHandler):
+    @staticmethod
+    def _get_attributes(record: logging.LogRecord):
+        attributes = LoggingHandler._get_attributes(record)
+        if isinstance(attributes, dict):
+            if isinstance(attributes.get("request"), HttpRequest):
+                # opentelemetry.attributes.BoundedAttributes does not support HttpRequest
+                # Split request into compatible types if present
+                # This occurs when getting "Not Found" error
+                request: HttpRequest = attributes.pop("request")
+                attributes["request.path"] = request.path
+                attributes["request.method"] = request.method
+
+        return attributes
+
 
 LOG_CONFIG = {
     "version": 1,
@@ -21,7 +39,7 @@ LOG_CONFIG = {
     "handlers": {
         "console": {"level": "DEBUG", "class": "logging.StreamHandler", "formatter": "standard"},
         "otlp": {
-            "class": "opentelemetry.sdk._logs.LoggingHandler",
+            "class": "jolpica_api.logging.CustomLoggingHandler",
             "logger_provider": logger_provider,
         },
     },


### PR DESCRIPTION
## Why are you making this change?

After implementing opentelemetry logging, the following is being seen in newrelic
![image](https://github.com/user-attachments/assets/00c337f4-4c24-496e-963b-57c6252cb88c)
```
Invalid type ASGIRequest for attribute 'request' value. Expected one of ['bool', 'str', 'bytes', 'int', 'float'] or a sequence of those types
```

This occurs when someone visits an error page such as Not Found, like api.jolpi.ca/foobar
To resolve this we remove the offending attribute and replace it with compatible ones

## Contributing Checklist
- [ ] Unit tests for the changes are included in this PR.
- [ ] I have read and agreed to the [contributing guidelines](CONTRIBUTING.md).
