### PR TITLE
fix: Added Pitstops, Qualifying, Circuits, Constructors, Drivers Standings and Constructors standings endpoint docs

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -13,21 +13,21 @@ API for querying formula one data, with backwards compatible endpoints for the s
 ## Endpoints and Documentation:
 For gaps in our documentation, please check the ergast docs [here](http://ergast.com/mrd/). 
 
-| Endpoint                              | Route |
-|-----                                  |-----|
-| Circuits                              | `/ergast/f1/circuits` |
-| Constructors                          | `/ergast/f1/constructors`|
-| Constructor Standings                 | `/ergast/f1/{season}/constructorstandings`|
-| [Drivers](/docs/endpoints/drivers.md) | `/ergast/f1/drivers`|
-| Driver Standings                      | `/ergast/f1/{season}/driverstandings`|
-| Laps                                  | `/ergast/f1/{season}/{round}/laps`|
-| Pitstops                              | `/ergast/f1/{season}/{round}/pitstops`|
-| Qualifying                            | `/ergast/f1/{season}/qualifying`|
-| [Races](/docs/endpoitns/races.md)     | `/ergast/f1/races`|
-| Results                               | `/ergast/f1/results`|
-| [Seasons](/docs/endpoints/seasons.md) | `/ergast/f1/seasons`|
-| Sprint                                | `/ergast/f1/sprint`|
-| Status                                |  `/ergast/f1/status`|
+| Endpoint                                          | Route |
+|-----                                              |-----|
+| Circuits                                          | `/ergast/f1/circuits` |
+| [Constructors](/docs/endpoints/constructors.md)   | `/ergast/f1/constructors`|
+| Constructor Standings                             | `/ergast/f1/{season}/constructorstandings`|
+| [Drivers](/docs/endpoints/drivers.md)             | `/ergast/f1/drivers`|
+| Driver Standings                                  | `/ergast/f1/{season}/driverstandings`|
+| Laps                                              | `/ergast/f1/{season}/{round}/laps`|
+| Pitstops                                          | `/ergast/f1/{season}/{round}/pitstops`|
+| Qualifying                                        | `/ergast/f1/{season}/qualifying`|
+| [Races](/docs/endpoitns/races.md)                 | `/ergast/f1/races`|
+| Results                                           | `/ergast/f1/results`|
+| [Seasons](/docs/endpoints/seasons.md)             | `/ergast/f1/seasons`|
+| Sprint                                            | `/ergast/f1/sprint`|
+| Status                                            |  `/ergast/f1/status`|
 
 ---
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -17,7 +17,7 @@ For gaps in our documentation, please check the ergast docs [here](http://ergast
 |-----                                                  |-----|
 | Circuits                                              | `/ergast/f1/circuits/`|
 | [Constructors](/docs/endpoints/constructors.md)       | `/ergast/f1/constructors/` |
-| Constructor Standings                                 | `/ergast/f1/{season}/constructorstandings/` |
+| [Constructor Standings](/docs/endpoints/constructorStandings.md)  | `/ergast/f1/{season}/constructorstandings/` |
 | [Drivers](/docs/endpoints/drivers.md)                 | `/ergast/f1/drivers/` |
 | [Driver Standings](/docs/endpoints/driverStandings.md)| `/ergast/f1/{season}/driverstandings/` |
 | Laps                                                  | `/ergast/f1/{season}/{round}/laps/` |
@@ -28,6 +28,8 @@ For gaps in our documentation, please check the ergast docs [here](http://ergast
 | [Seasons](/docs/endpoints/seasons.md)                 | `/ergast/f1/seasons/` |
 | Sprint                                                | `/ergast/f1/sprint/` |
 | Status                                                |  `/ergast/f1/status/` |
+
+Note: All endpoints should either end with a `/` or `.json`
 
 ---
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -22,7 +22,7 @@ For gaps in our documentation, please check the ergast docs [here](http://ergast
 | [Driver Standings](/docs/endpoints/driverStandings.md)| `/ergast/f1/{season}/driverstandings/` |
 | Laps                                                  | `/ergast/f1/{season}/{round}/laps/` |
 | [Pitstops](/docs/endpoints/pitstops.md)               | `/ergast/f1/{season}/{round}/pitstops/` |
-| Qualifying                                            | `/ergast/f1/{season}/qualifying/` |
+| [Qualifying](/docs/endpoints/qualifying)              | `/ergast/f1/{season}/qualifying/` |
 | [Races](/docs/endpoitns/races.md)                     | `/ergast/f1/races/` |
 | Results                                               | `/ergast/f1/results/` |
 | [Seasons](/docs/endpoints/seasons.md)                 | `/ergast/f1/seasons/` |

--- a/docs/README.md
+++ b/docs/README.md
@@ -21,7 +21,7 @@ For gaps in our documentation, please check the ergast docs [here](http://ergast
 | [Drivers](/docs/endpoints/drivers.md)                 | `/ergast/f1/drivers/` |
 | [Driver Standings](/docs/endpoints/driverStandings.md)| `/ergast/f1/{season}/driverstandings/` |
 | Laps                                                  | `/ergast/f1/{season}/{round}/laps/` |
-| Pitstops                                              | `/ergast/f1/{season}/{round}/pitstops/` |
+| [Pitstops](/docs/endpoints/pitstops.md)               | `/ergast/f1/{season}/{round}/pitstops/` |
 | Qualifying                                            | `/ergast/f1/{season}/qualifying/` |
 | [Races](/docs/endpoitns/races.md)                     | `/ergast/f1/races/` |
 | Results                                               | `/ergast/f1/results/` |

--- a/docs/README.md
+++ b/docs/README.md
@@ -15,19 +15,19 @@ For gaps in our documentation, please check the ergast docs [here](http://ergast
 
 | Endpoint                                              | Route |
 |-----                                                  |-----|
-| Circuits                                              | `/ergast/f1/circuits` |
-| [Constructors](/docs/endpoints/constructors.md)       | `/ergast/f1/constructors`|
-| Constructor Standings                                 | `/ergast/f1/{season}/constructorstandings`|
-| [Drivers](/docs/endpoints/drivers.md)                 | `/ergast/f1/drivers`|
-| [Driver Standings](/docs/endpoints/driverStandings.md)| `/ergast/f1/{season}/driverstandings`|
-| Laps                                                  | `/ergast/f1/{season}/{round}/laps`|
-| Pitstops                                              | `/ergast/f1/{season}/{round}/pitstops`|
-| Qualifying                                            | `/ergast/f1/{season}/qualifying`|
-| [Races](/docs/endpoitns/races.md)                     | `/ergast/f1/races`|
-| Results                                               | `/ergast/f1/results`|
-| [Seasons](/docs/endpoints/seasons.md)                 | `/ergast/f1/seasons`|
-| Sprint                                                | `/ergast/f1/sprint`|
-| Status                                                |  `/ergast/f1/status`|
+| Circuits                                              | `/ergast/f1/circuits/`|
+| [Constructors](/docs/endpoints/constructors.md)       | `/ergast/f1/constructors/` |
+| Constructor Standings                                 | `/ergast/f1/{season}/constructorstandings/` |
+| [Drivers](/docs/endpoints/drivers.md)                 | `/ergast/f1/drivers/` |
+| [Driver Standings](/docs/endpoints/driverStandings.md)| `/ergast/f1/{season}/driverstandings/` |
+| Laps                                                  | `/ergast/f1/{season}/{round}/laps/` |
+| Pitstops                                              | `/ergast/f1/{season}/{round}/pitstops/` |
+| Qualifying                                            | `/ergast/f1/{season}/qualifying/` |
+| [Races](/docs/endpoitns/races.md)                     | `/ergast/f1/races/` |
+| Results                                               | `/ergast/f1/results/` |
+| [Seasons](/docs/endpoints/seasons.md)                 | `/ergast/f1/seasons/` |
+| Sprint                                                | `/ergast/f1/sprint/` |
+| Status                                                |  `/ergast/f1/status/` |
 
 ---
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -13,21 +13,21 @@ API for querying formula one data, with backwards compatible endpoints for the s
 ## Endpoints and Documentation:
 For gaps in our documentation, please check the ergast docs [here](http://ergast.com/mrd/). 
 
-| Endpoint                                          | Route |
-|-----                                              |-----|
-| Circuits                                          | `/ergast/f1/circuits` |
-| [Constructors](/docs/endpoints/constructors.md)   | `/ergast/f1/constructors`|
-| Constructor Standings                             | `/ergast/f1/{season}/constructorstandings`|
-| [Drivers](/docs/endpoints/drivers.md)             | `/ergast/f1/drivers`|
-| [Driver Standings](/docs/endpoints/driverStandings.md)                                  | `/ergast/f1/{season}/driverstandings`|
-| Laps                                              | `/ergast/f1/{season}/{round}/laps`|
-| Pitstops                                          | `/ergast/f1/{season}/{round}/pitstops`|
-| Qualifying                                        | `/ergast/f1/{season}/qualifying`|
-| [Races](/docs/endpoitns/races.md)                 | `/ergast/f1/races`|
-| Results                                           | `/ergast/f1/results`|
-| [Seasons](/docs/endpoints/seasons.md)             | `/ergast/f1/seasons`|
-| Sprint                                            | `/ergast/f1/sprint`|
-| Status                                            |  `/ergast/f1/status`|
+| Endpoint                                              | Route |
+|-----                                                  |-----|
+| Circuits                                              | `/ergast/f1/circuits` |
+| [Constructors](/docs/endpoints/constructors.md)       | `/ergast/f1/constructors`|
+| Constructor Standings                                 | `/ergast/f1/{season}/constructorstandings`|
+| [Drivers](/docs/endpoints/drivers.md)                 | `/ergast/f1/drivers`|
+| [Driver Standings](/docs/endpoints/driverStandings.md)| `/ergast/f1/{season}/driverstandings`|
+| Laps                                                  | `/ergast/f1/{season}/{round}/laps`|
+| Pitstops                                              | `/ergast/f1/{season}/{round}/pitstops`|
+| Qualifying                                            | `/ergast/f1/{season}/qualifying`|
+| [Races](/docs/endpoitns/races.md)                     | `/ergast/f1/races`|
+| Results                                               | `/ergast/f1/results`|
+| [Seasons](/docs/endpoints/seasons.md)                 | `/ergast/f1/seasons`|
+| Sprint                                                | `/ergast/f1/sprint`|
+| Status                                                |  `/ergast/f1/status`|
 
 ---
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -19,7 +19,7 @@ For gaps in our documentation, please check the ergast docs [here](http://ergast
 | [Constructors](/docs/endpoints/constructors.md)   | `/ergast/f1/constructors`|
 | Constructor Standings                             | `/ergast/f1/{season}/constructorstandings`|
 | [Drivers](/docs/endpoints/drivers.md)             | `/ergast/f1/drivers`|
-| Driver Standings                                  | `/ergast/f1/{season}/driverstandings`|
+| [Driver Standings](/docs/endpoints/driverStandings.md)                                  | `/ergast/f1/{season}/driverstandings`|
 | Laps                                              | `/ergast/f1/{season}/{round}/laps`|
 | Pitstops                                          | `/ergast/f1/{season}/{round}/pitstops`|
 | Qualifying                                        | `/ergast/f1/{season}/qualifying`|

--- a/docs/README.md
+++ b/docs/README.md
@@ -15,7 +15,7 @@ For gaps in our documentation, please check the ergast docs [here](http://ergast
 
 | Endpoint                                              | Route |
 |-----                                                  |-----|
-| Circuits                                              | `/ergast/f1/circuits/`|
+| [Circuits](/docs/endpoints/circuits.md)               | `/ergast/f1/circuits/`|
 | [Constructors](/docs/endpoints/constructors.md)       | `/ergast/f1/constructors/` |
 | [Constructor Standings](/docs/endpoints/constructorStandings.md)  | `/ergast/f1/{season}/constructorstandings/` |
 | [Drivers](/docs/endpoints/drivers.md)                 | `/ergast/f1/drivers/` |

--- a/docs/endpoints/circuits.md
+++ b/docs/endpoints/circuits.md
@@ -1,7 +1,7 @@
 [← Documentation Home](/docs/README.md)
 # Circuits
 
-Gets list of circuits in alphabetical order by circuitId
+Returns list of circuits in alphabetical order by `circuitId`
 
 **URL** : `/ergast/f1/circuits/`
 
@@ -9,31 +9,31 @@ Gets list of circuits in alphabetical order by circuitId
 
 ---
 
-## Route Parameters:
+## Route Parameters
 
 ### Season
 
-**Filters only circuits which hosted a race in a given seasons. Year numbers are valid as is `current` to get the current season list of circuits**
+Filters only circuits which hosted a race in a given season. Year numbers are valid as is `current` to get the current season's list of circuits.
 
 `/{season}/` -> ex: `/ergast/f1/2024/circuits/`
 
-**Note**: To utilize the `season` parameter it needs to be the first route after `/ergast/f1/`
+**Note**: To utilize the `season` parameter, it needs to be the first argument after `/ergast/f1/`.
 
 ---
 
 ### Round
 
-**Filters only for the circuit that hosted the race in the specified round of the specific season. Round numbers 1 -> n races are valid as well as `last` and `next`**
+Filters only for the circuit that hosted the race in the specified round of the specific season. Round numbers 1 -> `n` races are valid as well as `last` and `next`.
 
 `/{round}/` -> ex: `/ergast/f1/2024/1/circuits/`
 
-**Note**: To utilize the `round` parameter it needs to be used with the `season` filter and be the first route after `/ergast/f1/{season}`
+**Note**: **Note**: To utilize the `round` parameter it needs to be used with the `season` filter and be the first argument after `/ergast/f1/{season}`.
 
 ---
 
 ### circuits
 
-**Filters for only the circuit that matches the specified circuitId**
+Filters for only the circuit that matches the specified `circuitId`..
 
 `/circuits/{circuitId}/` -> ex: `/ergast/f1/2024/circuits/albert_park/circuits/`
 
@@ -41,7 +41,7 @@ Gets list of circuits in alphabetical order by circuitId
 
 ### constructors
 
-**Filters for only circuits that the specified constructor has participated in a race at**
+Filters for only circuits that the specified constructor has participated in a race at.
 
 `/constructors/{constructorId}/` -> ex: `/ergast/f1/constructors/williams/circuits/`
 
@@ -49,7 +49,7 @@ Gets list of circuits in alphabetical order by circuitId
 
 ### drivers
 
-**Filters for only circuits that the specified driver has participated in a race at**
+Filters for only circuits that the specified driver has participated in a race at.
 
 `/drivers/{driverId}/` -> ex: `/ergast/f1/drivers/hamilton/circuits/`
 
@@ -58,7 +58,7 @@ Gets list of circuits in alphabetical order by circuitId
 
 ### fastest
 
-**Filters for only circuits that have had a race with a lap that was the ranked in the specified position**
+Filters for a list of circuits where a race finished with a driver completing a lap that was the ranked in the specified position.
 
 `/fastest/{lapRank}/` -> ex: `/ergast/f1/fastest/24/circuits/`
 
@@ -67,7 +67,7 @@ Gets list of circuits in alphabetical order by circuitId
 
 ### grid
 
-**Filters for only circuits that have had a race with a specific grid position**
+Filters for only circuits that have had a race with a specific grid position.
 
 `/grid/{gridPosition}/` -> ex: `/ergast/f1/grid/29/circuits/`
 
@@ -75,7 +75,7 @@ Gets list of circuits in alphabetical order by circuitId
 
 ### results
 
-**Filters for only circuits that have had a race where a specific finishing position was valid**
+Filters for only circuits that have had a race where a specific finishing position was valid.
 
 `/results/{finishPosition}/` -> ex: `/ergast/f1/results/1/circuits/`
 
@@ -83,7 +83,7 @@ Gets list of circuits in alphabetical order by circuitId
 
 ### status
 
-**Filters for only circuits that have had a race where a driver finished with a specific statusId**
+Filters for only circuits that have had a race where a driver finished with a specific `statusId`.
 
 `/status/{statusId}/` -> ex: `/ergast/f1/status/2/drivers/`
 
@@ -101,7 +101,7 @@ Gets list of circuits in alphabetical order by circuitId
 
 `MRData.CircuitTable.Circuits` : The list of all drivers returned.
 
-`MRData.CircuitTable.Circuits[i]` : A given driver object
+`MRData.CircuitTable.Circuits[i]` : A given driver object.
 
 ---
 

--- a/docs/endpoints/circuits.md
+++ b/docs/endpoints/circuits.md
@@ -5,7 +5,7 @@ Gets list of circuits in alphabetical order by circuitId
 
 **URL** : `/ergast/f1/circuits/`
 
-[Available Query Parameters](./README.md#query-parameters)
+[Available Query Parameters](docs/README.md#query-parameters)
 
 ---
 

--- a/docs/endpoints/circuits.md
+++ b/docs/endpoints/circuits.md
@@ -107,12 +107,12 @@ Gets list of circuits in alphabetical order by circuitId
 
 ## Circuits Object Fields:
 
-|Field|Always Included|
-|---|:---:|
-|circuitId| ✅ |
-|url|✅|
-|circuitName|✅|
-|Location|✅|
+|Field|Always Included|Description|type|
+|---|:---:|---|---|
+|circuitId|✅|Unique ID of the circuit|String
+|url|✅|Wikipedia URL of circuit|String
+|circuitName|✅|Name of the Circuit|String
+|Location|✅|Location of circuit (lat, long, locality, country)|Object
 
 ---
 

--- a/docs/endpoints/circuits.md
+++ b/docs/endpoints/circuits.md
@@ -1,0 +1,209 @@
+[← Documentation Home](/docs/README.md)
+# Circuits
+
+Gets list of circuits in alphabetical order by circuitId
+
+**URL** : `/ergast/f1/circuits/`
+
+[Available Query Parameters](./README.md#query-parameters)
+
+---
+
+## Route Parameters:
+
+### Season
+
+**Filters only circuits which hosted a race in a given seasons. Year numbers are valid as is `current` to get the current season list of circuits**
+
+`/{season}/` -> ex: `/ergast/f1/2024/circuits/`
+
+**Note**: To utilize the `season` parameter it needs to be the first route after `/ergast/f1/`
+
+---
+
+### Round
+
+**Filters only for the circuit that hosted the race in the specified round of the specific season. Round numbers 1 -> n races are valid as well as `last` and `next`**
+
+`/{round}/` -> ex: `/ergast/f1/2024/1/circuits/`
+
+**Note**: To utilize the `round` parameter it needs to be used with the `season` filter and be the first route after `/ergast/f1/{season}`
+
+---
+
+### circuits
+
+**Filters for only the circuit that matches the specified circuitId**
+
+`/circuits/{circuitId}/` -> ex: `/ergast/f1/2024/circuits/albert_park/circuits/`
+
+---
+
+### constructors
+
+**Filters for only circuits that the specified constructor has participated in a race at**
+
+`/constructors/{constructorId}/` -> ex: `/ergast/f1/constructors/williams/circuits/`
+
+---
+
+### drivers
+
+**Filters for only circuits that the specified driver has participated in a race at**
+
+`/drivers/{driverId}/` -> ex: `/ergast/f1/drivers/hamilton/circuits/`
+
+
+---
+
+### fastest
+
+**Filters for only circuits that have had a race with a lap that was the ranked in the specified position**
+
+`/fastest/{lapRank}/` -> ex: `/ergast/f1/fastest/24/circuits/`
+
+
+---
+
+### grid
+
+**Filters for only circuits that have had a race with a specific grid position**
+
+`/grid/{gridPosition}/` -> ex: `/ergast/f1/grid/29/circuits/`
+
+---
+
+### results
+
+**Filters for only circuits that have had a race where a specific finishing position was valid**
+
+`/results/{finishPosition}/` -> ex: `/ergast/f1/results/1/circuits/`
+
+---
+
+### status
+
+**Filters for only circuits that have had a race where a driver finished with a specific statusId**
+
+`/status/{statusId}/` -> ex: `/ergast/f1/status/2/drivers/`
+
+---
+
+## Success Response
+
+**Code** : `200 OK`
+
+**Response Fields** :
+
+[Common Response Fields](./README.md#common-response-fields)
+
+`MRData.CircuitTable` : The object containing the list of the all drivers.
+
+`MRData.CircuitTable.Circuits` : The list of all drivers returned.
+
+`MRData.CircuitTable.Circuits[i]` : A given driver object
+
+---
+
+## Driver Object Fields:
+
+|Field|Required|
+|---|:---:|
+|circuitId| ✅ |
+|url|✅|
+|circuitName|✅|
+|Location|✅|
+
+---
+
+## Examples:
+
+### Get list of all drivers in F1 history
+
+`https://api.jolpi.ca/ergast/f1/drivers/`
+
+```json
+{
+  "MRData": {
+    "xmlns": "",
+    "series": "f1",
+    "url": "http://api.jolpi.ca/ergast/f1/circuits/",
+    "limit": "30",
+    "offset": "0",
+    "total": "77",
+    "CircuitTable": {
+      "Circuits": [
+        {
+          "circuitId": "adelaide",
+          "url": "http://en.wikipedia.org/wiki/Adelaide_Street_Circuit",
+          "circuitName": "Adelaide Street Circuit",
+          "Location": {
+            "lat": "-34.9272",
+            "long": "138.617",
+            "locality": "Adelaide",
+            "country": "Australia"
+          }
+        },
+        {
+          "circuitId": "ain-diab",
+          "url": "http://en.wikipedia.org/wiki/Ain-Diab_Circuit",
+          "circuitName": "Ain Diab",
+          "Location": {
+            "lat": "33.5786",
+            "long": "-7.6875",
+            "locality": "Casablanca",
+            "country": "Morocco"
+          }
+        },
+        {
+          "circuitId": "aintree",
+          "url": "http://en.wikipedia.org/wiki/Aintree_Motor_Racing_Circuit",
+          "circuitName": "Aintree",
+          "Location": {
+            "lat": "53.4769",
+            "long": "-2.94056",
+            "locality": "Liverpool",
+            "country": "UK"
+          }
+        },
+        ...more
+      ]
+    }
+  }
+}
+```
+
+### Get all circuits which have had a race with 29 driver results.
+
+* Note this is missing Logan Sargent as he did not start the race even though he participated in the weekend.
+
+`https://api.jolpi.ca/ergast/f1/results/29/circuits/`
+
+```json
+{
+  "MRData": {
+    "xmlns": "",
+    "series": "f1",
+    "url": "http://api.jolpi.ca/ergast/f1/results/29/circuits/",
+    "limit": "30",
+    "offset": "0",
+    "total": "1",
+    "CircuitTable": {
+      "position": "29",
+      "Circuits": [
+        {
+          "circuitId": "indianapolis",
+          "url": "http://en.wikipedia.org/wiki/Indianapolis_Motor_Speedway",
+          "circuitName": "Indianapolis Motor Speedway",
+          "Location": {
+            "lat": "39.795",
+            "long": "-86.2347",
+            "locality": "Indianapolis",
+            "country": "USA"
+          }
+        }
+      ]
+    }
+  }
+}
+```

--- a/docs/endpoints/circuits.md
+++ b/docs/endpoints/circuits.md
@@ -107,7 +107,7 @@ Gets list of circuits in alphabetical order by circuitId
 
 ## Circuits Object Fields:
 
-|Field|Required|
+|Field|Always Included|
 |---|:---:|
 |circuitId| ✅ |
 |url|✅|

--- a/docs/endpoints/circuits.md
+++ b/docs/endpoints/circuits.md
@@ -95,7 +95,7 @@ Gets list of circuits in alphabetical order by circuitId
 
 **Response Fields** :
 
-[Common Response Fields](./README.md#common-response-fields)
+[Common Response Fields](docs/README.md#common-response-fields)
 
 `MRData.CircuitTable` : The object containing the list of the all drivers.
 
@@ -174,8 +174,6 @@ Gets list of circuits in alphabetical order by circuitId
 ```
 
 ### Get all circuits which have had a race with 29 driver results.
-
-* Note this is missing Logan Sargent as he did not start the race even though he participated in the weekend.
 
 `https://api.jolpi.ca/ergast/f1/results/29/circuits/`
 

--- a/docs/endpoints/circuits.md
+++ b/docs/endpoints/circuits.md
@@ -1,7 +1,7 @@
 [← Documentation Home](/docs/README.md)
 # Circuits
 
-Returns list of circuits in alphabetical order by `circuitId`
+Returns a list of circuits in alphabetical order by `circuitId`
 
 **URL** : `/ergast/f1/circuits/`
 

--- a/docs/endpoints/circuits.md
+++ b/docs/endpoints/circuits.md
@@ -5,7 +5,7 @@ Gets list of circuits in alphabetical order by circuitId
 
 **URL** : `/ergast/f1/circuits/`
 
-[Available Query Parameters](docs/README.md#query-parameters)
+[Available Query Parameters](/docs/README.md#query-parameters)
 
 ---
 
@@ -95,7 +95,7 @@ Gets list of circuits in alphabetical order by circuitId
 
 **Response Fields** :
 
-[Common Response Fields](docs/README.md#common-response-fields)
+[Common Response Fields](/docs/README.md#common-response-fields)
 
 `MRData.CircuitTable` : The object containing the list of the all drivers.
 

--- a/docs/endpoints/circuits.md
+++ b/docs/endpoints/circuits.md
@@ -105,7 +105,7 @@ Gets list of circuits in alphabetical order by circuitId
 
 ---
 
-## Driver Object Fields:
+## Circuits Object Fields:
 
 |Field|Required|
 |---|:---:|

--- a/docs/endpoints/constructorStandings.md
+++ b/docs/endpoints/constructorStandings.md
@@ -79,7 +79,7 @@ Gets a season's constructors standings
 |positonText|✅|
 |points|✅|
 |wins|✅|
-|Constructors|✅|
+|Constructor|✅|
 
 ---
 

--- a/docs/endpoints/constructorStandings.md
+++ b/docs/endpoints/constructorStandings.md
@@ -5,7 +5,7 @@ Gets a season's constructors standings from first to last place.
 
 **URL** : `/ergast/f1/{season}/constructorstandings/`
 
-[Available Query Parameters](docs/README.md#query-parameters)
+[Available Query Parameters](/docs/README.md#query-parameters)
 
 ---
 

--- a/docs/endpoints/constructorStandings.md
+++ b/docs/endpoints/constructorStandings.md
@@ -1,7 +1,7 @@
 [← Documentation Home](/docs/README.md)
 # Constructor Standings
 
-Gets a season's constructors standings 
+Gets a season's constructors standings from first to last place.
 
 **URL** : `/ergast/f1/{season}/constructorstandings/`
 

--- a/docs/endpoints/constructorStandings.md
+++ b/docs/endpoints/constructorStandings.md
@@ -13,7 +13,7 @@ Gets a season's constructors standings
 
 ### Season \*\*REQUIRED\*\*
 
-**Filters for the constructors standing of a specified season. Year numbers are valid as is 'current' to get the current seasons constructors standings**
+**Filters for the constructors standing of a specified season. Year numbers are valid as is `current` to get the current seasons constructors standings**
 
 `/{season}/` -> ex: `/ergast/f1/2024/constructorstandings/`
 
@@ -23,7 +23,7 @@ Gets a season's constructors standings
 
 ### Round
 
-**Filters for the constructors standings after a specified round in a specific season. Round numbers 1 -> n races are valid as well as 'last'**
+**Filters for the constructors standings after a specified round in a specific season. Round numbers 1 -> n races are valid as well as `last`**
 
 `/{season}/{roundNumber}/` -> ex: `/ergast/f1/2024/5/constructorstandings/`
 

--- a/docs/endpoints/constructorStandings.md
+++ b/docs/endpoints/constructorStandings.md
@@ -43,7 +43,7 @@ Gets a season's constructors standings
 
 **Filters for only the constructor in a given position in a given year**
 
-`/{position}` -> ex: `/ergast/f1/2024/constructorstandings/1/`
+`/{finishPosition}` -> ex: `/ergast/f1/2024/constructorstandings/1/`
 
 **Note**: The position must be at the end after any filters and after `/constructorstandings/`
 

--- a/docs/endpoints/constructorStandings.md
+++ b/docs/endpoints/constructorStandings.md
@@ -1,0 +1,205 @@
+[← Documentation Home](/docs/README.md)
+# Constructor Standings
+
+Gets a season's constructors standings 
+
+**URL** : `/ergast/f1/{YEAR}/constructorstandings/`
+
+[Available Query Parameters](./README.md#query-parameters)
+
+---
+
+## Route Parameters:
+
+### Season \*\*REQUIRED\*\*
+
+**Filters for the constructors standing of a specified season. Year numbers are valid as is 'current' to get the current seasons constructors standings**
+
+`/{season}/` -> ex: `/ergast/f1/2024/constructorstandings/`
+
+**Note**: To utilize the `season` parameter it needs to be the first route after `/ergast/f1/`
+
+---
+
+### Round
+
+**Filters for the constructors standings after a specified round in a specific season. Round numbers 1 -> n races are valid as well as 'last'**
+
+`/{season}/{roundNumber}/` -> ex: `/ergast/f1/2024/5/constructorstandings/`
+
+**Note**: To utilize the `round` parameter it must be combined with a season filter and needs to be the first route after `/ergast/f1/{season}/`
+
+---
+
+### constructors
+
+**Filters for only for a specific constructors's constructors standing information for a given year**
+
+`/constructors/{constructorsId}/` -> ex: `/ergast/f1/2024/constructors/ferrari/constructorstandings/`
+
+---
+
+### position
+
+**Filters for only the constructor in a given position in a given year**
+
+`/{position}` -> ex: `/ergast/f1/2024/constructorstandings/1/`
+
+**Note**: The position must be at the end after any filters and after `/constructorstandings/`
+
+---
+
+## Success Response
+
+**Code** : `200 OK`
+
+**Response Fields** :
+
+[Common Response Fields](./README.md#common-response-fields)
+
+`MRData.StandingsTable` : The object containing the season's constructors standing information.
+
+`MRData.StandingsTable.season` : The filtered season.
+
+`MRData.StandingsTable.round` : The round that the season the standings represent.
+
+`MRData.StandingsTable.StandingsLists` : The list of constructors standings.
+
+`MRData.StandingsTable.StandingsLists[i]` : A given constructors standings list object.
+
+`MRData.StandingsTable.StandingsLists[i].ConstructorStandings` : The list of constructors standings objects.
+
+---
+
+## Constrcutors Standing Object Fields:
+
+|Field|Required|
+|---|:---:|
+|position| ✅ |
+|positonText|✅|
+|points|✅|
+|wins|✅|
+|Constructors|✅|
+
+---
+
+## Examples:
+
+### Get the 2007 season's constructors standing information
+
+`https://api.jolpi.ca/ergast/f1/2007/constructorstandings/`
+
+```json
+{
+  "MRData": {
+    "xmlns": "",
+    "series": "f1",
+    "url": "http://api.jolpi.ca/ergast/f1/2007/constructorstandings/",
+    "limit": "30",
+    "offset": "0",
+    "total": "11",
+    "StandingsTable": {
+      "season": "2007",
+      "round": "17",
+      "StandingsLists": [
+        {
+          "season": "2007",
+          "round": "17",
+          "ConstructorStandings": [
+            {
+              "position": "1",
+              "positionText": "1",
+              "points": "204",
+              "wins": "9",
+              "Constructor": {
+                "constructorId": "ferrari",
+                "url": "http://en.wikipedia.org/wiki/Scuderia_Ferrari",
+                "name": "Ferrari",
+                "nationality": "Italian"
+              }
+            },
+            {
+              "position": "2",
+              "positionText": "2",
+              "points": "101",
+              "wins": "0",
+              "Constructor": {
+                "constructorId": "bmw_sauber",
+                "url": "http://en.wikipedia.org/wiki/BMW_Sauber",
+                "name": "BMW Sauber",
+                "nationality": "German"
+              }
+            },
+            ...more,
+            {
+              "positionText": "E",
+              "points": "0",
+              "wins": "8",
+              "Constructor": {
+                "constructorId": "mclaren",
+                "url": "http://en.wikipedia.org/wiki/McLaren",
+                "name": "McLaren",
+                "nationality": "British"
+              }
+            }
+          ]
+        }
+      ]
+    }
+  }
+}
+```
+
+### Get the 2020 constructors standing after the 9th round
+
+`http://api.jolpi.ca/ergast/f1/2020/9/constructorstandings/`
+
+```json
+{
+  "MRData": {
+    "xmlns": "",
+    "series": "f1",
+    "url": "http://api.jolpi.ca/ergast/f1/2020/9/constructorstandings/",
+    "limit": "30",
+    "offset": "0",
+    "total": "10",
+    "StandingsTable": {
+      "season": "2020",
+      "round": "9",
+      "StandingsLists": [
+        {
+          "season": "2020",
+          "round": "9",
+          "ConstructorStandings": [
+            {
+              "position": "1",
+              "positionText": "1",
+              "points": "325",
+              "wins": "7",
+              "Constructor": {
+                "constructorId": "mercedes",
+                "url": "http://en.wikipedia.org/wiki/Mercedes-Benz_in_Formula_One",
+                "name": "Mercedes",
+                "nationality": "German"
+              }
+            },
+            {
+              "position": "2",
+              "positionText": "2",
+              "points": "173",
+              "wins": "1",
+              "Constructor": {
+                "constructorId": "red_bull",
+                "url": "http://en.wikipedia.org/wiki/Red_Bull_Racing",
+                "name": "Red Bull",
+                "nationality": "Austrian"
+              }
+            },
+            ...more
+          ]
+        }
+      ]
+    }
+  }
+}
+```

--- a/docs/endpoints/constructorStandings.md
+++ b/docs/endpoints/constructorStandings.md
@@ -5,7 +5,7 @@ Gets a season's constructors standings from first to last place.
 
 **URL** : `/ergast/f1/{season}/constructorstandings/`
 
-[Available Query Parameters](./README.md#query-parameters)
+[Available Query Parameters](docs/README.md#query-parameters)
 
 ---
 

--- a/docs/endpoints/constructorStandings.md
+++ b/docs/endpoints/constructorStandings.md
@@ -75,7 +75,7 @@ Gets a season's constructors standings from first to last place.
 
 |Field|Required|
 |---|:---:|
-|position| ❌ |
+|position| 🟡 |
 |positonText|✅|
 |points|✅|
 |wins|✅|

--- a/docs/endpoints/constructorStandings.md
+++ b/docs/endpoints/constructorStandings.md
@@ -75,11 +75,12 @@ Gets a season's constructors standings from first to last place.
 
 |Field|Required|
 |---|:---:|
-|position| ✅ |
+|position| ❌ |
 |positonText|✅|
 |points|✅|
 |wins|✅|
 |Constructor|✅|
+Possible values for positionText include: `E` Excluded (2007 McLaren), `D` Disqualified, `-` for ineligible or the position as a string otherwise.  
 
 ---
 

--- a/docs/endpoints/constructorStandings.md
+++ b/docs/endpoints/constructorStandings.md
@@ -1,7 +1,7 @@
 [← Documentation Home](/docs/README.md)
 # Constructor Standings
 
-Gets a season's constructors standings from first to last place.
+Returns a season's constructors standings from first to last place.
 
 **URL** : `/ergast/f1/{season}/constructorstandings/`
 
@@ -9,31 +9,31 @@ Gets a season's constructors standings from first to last place.
 
 ---
 
-## Route Parameters:
+## Route Parameters
 
-### Season \*\*REQUIRED\*\*
+### Season (required)
 
-**Filters for the constructors standing of a specified season. Year numbers are valid as is `current` to get the current seasons constructors standings**
+Filters for the constructors standing of a specified season. Year numbers are valid as is `current` to get the current seasons constructors standings.
 
 `/{season}/` -> ex: `/ergast/f1/2024/constructorstandings/`
 
-**Note**: To utilize the `season` parameter it needs to be the first route after `/ergast/f1/`
+**Note**: To utilize the `season` parameter, it needs to be the first argument after `/ergast/f1/`.
 
 ---
 
 ### Round
 
-**Filters for the constructors standings after a specified round in a specific season. Round numbers 1 -> n races are valid as well as `last`**
+Filters for the constructors standings after a specified round in a specific season. Round numbers 1 -> `n` races are valid as well as `last`.
 
 `/{season}/{round}/` -> ex: `/ergast/f1/2024/5/constructorstandings/`
 
-**Note**: To utilize the `round` parameter it must be combined with a season filter and needs to be the first route after `/ergast/f1/{season}/`
+**Note**: To utilize the `round` parameter it must be combined with a season filter and needs to be the first argument after `/ergast/f1/{season}/`.
 
 ---
 
 ### constructors
 
-**Filters for only for a specific constructors's constructors standing information for a given year**
+Filters for only for a specific constructors' standing information for a given year.
 
 `/constructors/{constructorsId}/` -> ex: `/ergast/f1/2024/constructors/ferrari/constructorstandings/`
 
@@ -41,7 +41,7 @@ Gets a season's constructors standings from first to last place.
 
 ### position
 
-**Filters for only the constructor in a given position in a given year**
+Filters for only the constructor in a given position in a given year.
 
 `/{finishPosition}` -> ex: `/ergast/f1/2024/constructorstandings/1/`
 

--- a/docs/endpoints/constructorStandings.md
+++ b/docs/endpoints/constructorStandings.md
@@ -3,7 +3,7 @@
 
 Gets a season's constructors standings 
 
-**URL** : `/ergast/f1/{YEAR}/constructorstandings/`
+**URL** : `/ergast/f1/{season}/constructorstandings/`
 
 [Available Query Parameters](./README.md#query-parameters)
 

--- a/docs/endpoints/constructorStandings.md
+++ b/docs/endpoints/constructorStandings.md
@@ -73,7 +73,7 @@ Gets a season's constructors standings from first to last place.
 
 ## Constrcutors Standing Object Fields:
 
-|Field|Required|
+|Field|Always Included|
 |---|:---:|
 |position| 🟡 |
 |positonText|✅|

--- a/docs/endpoints/constructorStandings.md
+++ b/docs/endpoints/constructorStandings.md
@@ -73,14 +73,15 @@ Gets a season's constructors standings from first to last place.
 
 ## Constrcutors Standing Object Fields:
 
-|Field|Always Included|
-|---|:---:|
-|position| 🟡 |
-|positonText|✅|
-|points|✅|
-|wins|✅|
-|Constructor|✅|
-Possible values for positionText include: `E` Excluded (2007 McLaren), `D` Disqualified, `-` for ineligible or the position as a string otherwise.  
+|Field|Always Included|Description|type
+|---|:---:|---|---|
+|position|🟡|Position in the Championship|String
+|positonText|✅|Description of position `*`|String
+|points|✅|Total points in the Championship|String
+|wins|✅|Count of race wins|String
+|Constructor|✅|Constructor information (constructorId, name, url, nationality)|Object
+
+`*` - Possible values for positionText include: `E` Excluded (2007 McLaren), `D` Disqualified, `-` for ineligible or the position as a string otherwise.  
 
 ---
 

--- a/docs/endpoints/constructorStandings.md
+++ b/docs/endpoints/constructorStandings.md
@@ -25,7 +25,7 @@ Gets a season's constructors standings
 
 **Filters for the constructors standings after a specified round in a specific season. Round numbers 1 -> n races are valid as well as `last`**
 
-`/{season}/{roundNumber}/` -> ex: `/ergast/f1/2024/5/constructorstandings/`
+`/{season}/{round}/` -> ex: `/ergast/f1/2024/5/constructorstandings/`
 
 **Note**: To utilize the `round` parameter it must be combined with a season filter and needs to be the first route after `/ergast/f1/{season}/`
 

--- a/docs/endpoints/constructors.md
+++ b/docs/endpoints/constructors.md
@@ -3,7 +3,7 @@
 
 Gets list of constructors 
 
-**URL** : `/ergast/f1/constructors`
+**URL** : `/ergast/f1/constructors/`
 
 [Available Query Parameters](./README.md#query-parameters)
 
@@ -15,7 +15,7 @@ Gets list of constructors
 
 **Filters only constructors that participated in a specified season. Year numbers are valid as is 'current' to get the current season list of constructors**
 
-`/{season}/` -> ex: `/ergast/f1/2024/constructors`
+`/{season}/` -> ex: `/ergast/f1/2024/constructors/`
 
 **Note**: To utilize the `season` parameter it needs to be the first route after `/ergast/f1/`
 
@@ -25,7 +25,7 @@ Gets list of constructors
 
 **Filters for only constructors who have participated in a race at a given circuit**
 
-`/circuits/{circuitId}/` -> ex: `/ergast/f1/circuits/bahrain/constructors`
+`/circuits/{circuitId}/` -> ex: `/ergast/f1/circuits/bahrain/constructors/`
 
 ---
 
@@ -33,7 +33,7 @@ Gets list of constructors
 
 **Filters for only a specified constructor**
 
-`/constructors/{constructorId}/` -> ex: `/ergast/f1/constructors/williams/constructors`
+`/constructors/{constructorId}/` -> ex: `/ergast/f1/constructors/williams/constructors/`
 
 ---
 
@@ -41,7 +41,7 @@ Gets list of constructors
 
 **Filters for only constructors that had a driver race for them**
 
-`/drivers/{driverId}/` -> ex: `/ergast/f1/drivers/hamilton/constructors`
+`/drivers/{driverId}/` -> ex: `/ergast/f1/drivers/hamilton/constructors/`
 
 
 ---
@@ -50,7 +50,7 @@ Gets list of constructors
 
 **Filters for only constructors that finished a race with a lap that was the ranked in the specified position**
 
-`/fastest/{lapRank}/` -> ex: `/ergast/f1/fastest/1/constructors`
+`/fastest/{lapRank}/` -> ex: `/ergast/f1/fastest/1/constructors/`
 
 
 ---
@@ -59,7 +59,7 @@ Gets list of constructors
 
 **Filters for only constructors which had a driver racing for them start a race in a specific grid position**
 
-`/grid/{gridPosition}/` -> ex: `/ergast/f1/grid/1/constructors`
+`/grid/{gridPosition}/` -> ex: `/ergast/f1/grid/1/constructors/`
 
 ---
 
@@ -67,7 +67,7 @@ Gets list of constructors
 
 **Filters for only constructors which had a driver racing for them finish a race in a specific position**
 
-`/results/{position}/` -> ex: `/ergast/f1/results/1/constructors`
+`/results/{position}/` -> ex: `/ergast/f1/results/1/constructors/`
 
 ---
 
@@ -75,7 +75,7 @@ Gets list of constructors
 
 **Filters for only constructors who had a driver finish a race with a specific statusId**
 
-`/status/{statusId}/` -> ex: `/ergast/f1/status/2/constructors`
+`/status/{statusId}/` -> ex: `/ergast/f1/status/2/constructors/`
 
 ---
 
@@ -110,7 +110,7 @@ Gets list of constructors
 
 ### Get list of all constructors in F1 history
 
-`https://api.jolpi.ca/ergast/f1/constructors`
+`https://api.jolpi.ca/ergast/f1/constructors/`
 
 ```json
 {
@@ -144,7 +144,7 @@ Gets list of constructors
 
 ### Get all constructors who had a driver who won a race
 
-`https://api.jolpi.ca/ergast/f1/results/1/constructors`
+`https://api.jolpi.ca/ergast/f1/results/1/constructors/`
 
 ```json
 {

--- a/docs/endpoints/constructors.md
+++ b/docs/endpoints/constructors.md
@@ -107,7 +107,7 @@ Gets list of constructors alphabetically by constructorId
 
 ## Constructor Object Fields:
 
-|Field|Required|
+|Field|Always Included|
 |---|:---:|
 |constructorId| 🟡 |
 |url|🟡|

--- a/docs/endpoints/constructors.md
+++ b/docs/endpoints/constructors.md
@@ -107,12 +107,12 @@ Gets list of constructors alphabetically by constructorId
 
 ## Constructor Object Fields:
 
-|Field|Always Included|
-|---|:---:|
-|constructorId| 🟡 |
-|url|🟡|
-|name|✅|
-|nationality|🟡|
+|Field|Always Included|Description|type
+|---|:---:|---|---|
+|constructorId|🟡|Unique ID of the constructor|String
+|url|🟡|Wikipedia URL of the circuit|String
+|name|✅|Name of the Constructor|String
+|nationality|🟡|Nationality Demonym|String
 
 ---
 

--- a/docs/endpoints/constructors.md
+++ b/docs/endpoints/constructors.md
@@ -1,0 +1,178 @@
+[← Documentation Home](/docs/README.md)
+# Constructors
+
+Gets list of constructors 
+
+**URL** : `/ergast/f1/constructors`
+
+[Available Query Parameters](./README.md#query-parameters)
+
+---
+
+## Route Parameters:
+
+### Season
+
+**Filters only constructors that participated in a specified season. Year numbers are valid as is 'current' to get the current season list of constructors**
+
+`/{season}/` -> ex: `/ergast/f1/2024/constructors`
+
+**Note**: To utilize the `season` parameter it needs to be the first route after `/ergast/f1/`
+
+---
+
+### circuits
+
+**Filters for only constructors who have participated in a race at a given circuit**
+
+`/circuits/{circuitId}/` -> ex: `/ergast/f1/circuits/bahrain/constructors`
+
+---
+
+### constructors
+
+**Filters for only a specified constructor**
+
+`/constructors/{constructorId}/` -> ex: `/ergast/f1/constructors/williams/constructors`
+
+---
+
+### drivers
+
+**Filters for only constructors that had a driver race for them**
+
+`/drivers/{driverId}/` -> ex: `/ergast/f1/drivers/hamilton/constructors`
+
+
+---
+
+### fastest
+
+**Filters for only constructors that finished a race with a lap that was the ranked in the specified position**
+
+`/fastest/{lapRank}/` -> ex: `/ergast/f1/fastest/1/constructors`
+
+
+---
+
+### grid
+
+**Filters for only constructors which had a driver racing for them start a race in a specific grid position**
+
+`/grid/{gridPosition}/` -> ex: `/ergast/f1/grid/1/constructors`
+
+---
+
+### results
+
+**Filters for only constructors which had a driver racing for them finish a race in a specific position**
+
+`/results/{position}/` -> ex: `/ergast/f1/results/1/constructors`
+
+---
+
+### status
+
+**Filters for only constructors who had a driver finish a race with a specific statusId**
+
+`/status/{statusId}/` -> ex: `/ergast/f1/status/2/constructors`
+
+---
+
+## Success Response
+
+**Code** : `200 OK`
+
+**Response Fields** :
+
+[Common Response Fields](./README.md#common-response-fields)
+
+`MRData.ConstructorTable` : The object containing the list of the all constructors.
+
+`MRData.ConstructorTable.Constructors` : The list of all constructors returned.
+
+`MRData.ConstructorTable.Constructors[i]` : A given constructor object
+
+---
+
+## Constructor Object Fields:
+
+|Field|Required|
+|---|:---:|
+|constructorId| ✅ |
+|url|✅|
+|name|✅|
+|nationality|✅|
+
+---
+
+## Examples:
+
+### Get list of all constructors in F1 history
+
+`https://api.jolpi.ca/ergast/f1/constructors`
+
+```json
+{
+  "MRData": {
+    "xmlns": "",
+    "series": "f1",
+    "url": "http://api.jolpi.ca/ergast/f1/constructors/",
+    "limit": "30",
+    "offset": "0",
+    "total": "212",
+    "ConstructorTable": {
+      "Constructors": [
+        {
+          "constructorId": "adams",
+          "url": "http://en.wikipedia.org/wiki/Adams_(constructor)",
+          "name": "Adams",
+          "nationality": "American"
+        },
+        {
+          "constructorId": "afm",
+          "url": "http://en.wikipedia.org/wiki/Alex_von_Falkenhausen_Motorenbau",
+          "name": "AFM",
+          "nationality": "German"
+        },
+        ...more
+      ]
+    }
+  }
+}
+```
+
+### Get all constructors who had a driver who won a race
+
+`https://api.jolpi.ca/ergast/f1/results/1/constructors`
+
+```json
+{
+  "MRData": {
+    "xmlns": "",
+    "series": "f1",
+    "url": "http://api.jolpi.ca/ergast/f1/results/1/constructors/",
+    "limit": "30",
+    "offset": "0",
+    "total": "47",
+    "ConstructorTable": {
+      "position": "1",
+      "Constructors": [
+        {
+          "constructorId": "alfa",
+          "url": "http://en.wikipedia.org/wiki/Alfa_Romeo_in_Formula_One",
+          "name": "Alfa Romeo",
+          "nationality": "Swiss"
+        },
+        {
+          "constructorId": "alphatauri",
+          "url": "http://en.wikipedia.org/wiki/Scuderia_AlphaTauri",
+          "name": "AlphaTauri",
+          "nationality": "Italian"
+        },
+        ...more
+      ]
+    }
+  }
+}
+```

--- a/docs/endpoints/constructors.md
+++ b/docs/endpoints/constructors.md
@@ -1,7 +1,7 @@
 [← Documentation Home](/docs/README.md)
 # Constructors
 
-Gets list of constructors 
+Gets list of constructors alphabetically by constructorId
 
 **URL** : `/ergast/f1/constructors/`
 

--- a/docs/endpoints/constructors.md
+++ b/docs/endpoints/constructors.md
@@ -112,7 +112,7 @@ Gets list of constructors alphabetically by constructorId
 |constructorId|🟡|Unique ID of the constructor|String
 |url|🟡|Wikipedia URL of the circuit|String
 |name|✅|Name of the Constructor|String
-|nationality|🟡|Nationality Demonym|String
+|nationality|🟡|Nationality|String
 
 ---
 

--- a/docs/endpoints/constructors.md
+++ b/docs/endpoints/constructors.md
@@ -5,7 +5,7 @@ Gets list of constructors alphabetically by constructorId
 
 **URL** : `/ergast/f1/constructors/`
 
-[Available Query Parameters](./README.md#query-parameters)
+[Available Query Parameters](docs/README.md#query-parameters)
 
 ---
 

--- a/docs/endpoints/constructors.md
+++ b/docs/endpoints/constructors.md
@@ -1,7 +1,7 @@
 [← Documentation Home](/docs/README.md)
 # Constructors
 
-Gets list of constructors alphabetically by constructorId
+Returns a list of constructors alphabetically by `constructorId`
 
 **URL** : `/ergast/f1/constructors/`
 
@@ -9,31 +9,31 @@ Gets list of constructors alphabetically by constructorId
 
 ---
 
-## Route Parameters:
+## Route Parameters
 
 ### Season
 
-**Filters only constructors that participated in a specified season. Year numbers are valid as is `current` to get the current season list of constructors**
+Filters only constructors that participated in a specified season. Year numbers are valid as is `current` to get the current season list of constructors.
 
 `/{season}/` -> ex: `/ergast/f1/2024/constructors/`
 
-**Note**: To utilize the `season` parameter it needs to be the first route after `/ergast/f1/`
+**Note**: To utilize the `season` parameter, it needs to be the first argument after `/ergast/f1/`.
 
 ---
 
 ### Round
 
-**Filters only constructors that participated in a specified round of a specific season. Round numbers 1 -> n races are valid as well as `last`**
+Filters only constructors that participated in a specified round of a specific season. Round numbers 1 -> `n` races are valid as well as `last`.
 
 `/{round}/` -> ex: `/ergast/f1/2024/1/constructors/`
 
-**Note**: To utilize the `round` parameter it needs to be used with the `season` filter and be the first route after `/ergast/f1/{season}/`
+**Note**: To utilize the `round` parameter it needs to be used with the `season` filter and be the first argument after `/ergast/f1/{season}/`
 
 ---
 
 ### circuits
 
-**Filters for only constructors who have participated in a race at a given circuit**
+Filters for only constructors who have participated in a race at a given circuit.
 
 `/circuits/{circuitId}/` -> ex: `/ergast/f1/circuits/bahrain/constructors/`
 
@@ -41,7 +41,7 @@ Gets list of constructors alphabetically by constructorId
 
 ### constructors
 
-**Filters for only a specified constructor**
+Filters for only a specified constructor.
 
 `/constructors/{constructorId}/` -> ex: `/ergast/f1/constructors/williams/`
 
@@ -49,7 +49,7 @@ Gets list of constructors alphabetically by constructorId
 
 ### drivers
 
-**Filters for only constructors that had a driver race for them**
+Filters for only constructors that had a driver race for them.
 
 `/drivers/{driverId}/` -> ex: `/ergast/f1/drivers/hamilton/constructors/`
 
@@ -58,7 +58,7 @@ Gets list of constructors alphabetically by constructorId
 
 ### fastest
 
-**Filters for only constructors that finished a race with a lap that was the ranked in the specified position**
+Filters for only constructors that finished a race with a lap that was the ranked in the specified position.
 
 `/fastest/{lapRank}/` -> ex: `/ergast/f1/fastest/1/constructors/`
 
@@ -67,7 +67,7 @@ Gets list of constructors alphabetically by constructorId
 
 ### grid
 
-**Filters for only constructors which had a driver racing for them start a race in a specific grid position**
+Filters for only constructors which had a driver racing for them start a race in a specific grid position.
 
 `/grid/{gridPosition}/` -> ex: `/ergast/f1/grid/1/constructors/`
 
@@ -75,7 +75,7 @@ Gets list of constructors alphabetically by constructorId
 
 ### results
 
-**Filters for only constructors which had a driver racing for them finish a race in a specific position**
+Filters for only constructors which had a driver racing for them finish a race in a specific position.
 
 `/results/{finishPosition}/` -> ex: `/ergast/f1/results/1/constructors/`
 
@@ -83,7 +83,7 @@ Gets list of constructors alphabetically by constructorId
 
 ### status
 
-**Filters for only constructors who had a driver finish a race with a specific statusId**
+Filters for only constructors who had a driver finish a race with a specific `statusId`.
 
 `/status/{statusId}/` -> ex: `/ergast/f1/status/2/constructors/`
 
@@ -101,7 +101,7 @@ Gets list of constructors alphabetically by constructorId
 
 `MRData.ConstructorTable.Constructors` : The list of all constructors returned.
 
-`MRData.ConstructorTable.Constructors[i]` : A given constructor object
+`MRData.ConstructorTable.Constructors[i]` : A given constructor object.
 
 ---
 

--- a/docs/endpoints/constructors.md
+++ b/docs/endpoints/constructors.md
@@ -5,7 +5,7 @@ Gets list of constructors alphabetically by constructorId
 
 **URL** : `/ergast/f1/constructors/`
 
-[Available Query Parameters](docs/README.md#query-parameters)
+[Available Query Parameters](/docs/README.md#query-parameters)
 
 ---
 

--- a/docs/endpoints/constructors.md
+++ b/docs/endpoints/constructors.md
@@ -13,7 +13,7 @@ Gets list of constructors
 
 ### Season
 
-**Filters only constructors that participated in a specified season. Year numbers are valid as is 'current' to get the current season list of constructors**
+**Filters only constructors that participated in a specified season. Year numbers are valid as is `current` to get the current season list of constructors**
 
 `/{season}/` -> ex: `/ergast/f1/2024/constructors/`
 

--- a/docs/endpoints/constructors.md
+++ b/docs/endpoints/constructors.md
@@ -43,7 +43,7 @@ Gets list of constructors alphabetically by constructorId
 
 **Filters for only a specified constructor**
 
-`/constructors/{constructorId}/` -> ex: `/ergast/f1/constructors/williams/constructors/`
+`/constructors/{constructorId}/` -> ex: `/ergast/f1/constructors/williams/`
 
 ---
 
@@ -109,10 +109,10 @@ Gets list of constructors alphabetically by constructorId
 
 |Field|Required|
 |---|:---:|
-|constructorId| ✅ |
-|url|✅|
+|constructorId| 🟡 |
+|url|🟡|
 |name|✅|
-|nationality|✅|
+|nationality|🟡|
 
 ---
 

--- a/docs/endpoints/constructors.md
+++ b/docs/endpoints/constructors.md
@@ -67,7 +67,7 @@ Gets list of constructors
 
 **Filters for only constructors which had a driver racing for them finish a race in a specific position**
 
-`/results/{position}/` -> ex: `/ergast/f1/results/1/constructors/`
+`/results/{finishPosition}/` -> ex: `/ergast/f1/results/1/constructors/`
 
 ---
 

--- a/docs/endpoints/constructors.md
+++ b/docs/endpoints/constructors.md
@@ -21,6 +21,16 @@ Gets list of constructors
 
 ---
 
+### Round
+
+**Filters only constructors that participated in a specified round of a specific season. Round numbers 1 -> n races are valid as well as `last`**
+
+`/{round}/` -> ex: `/ergast/f1/2024/1/constructors/`
+
+**Note**: To utilize the `round` parameter it needs to be used with the `season` filter and be the first route after `/ergast/f1/{season}/`
+
+---
+
 ### circuits
 
 **Filters for only constructors who have participated in a race at a given circuit**

--- a/docs/endpoints/driverStandings.md
+++ b/docs/endpoints/driverStandings.md
@@ -21,6 +21,16 @@ Gets a season's drivers standings
 
 ---
 
+### Round
+
+**Filters for the drivers standings after a specified round in a specific season. Round numbers 1 -> n races are valid as well as 'last'**
+
+`/{season}/{roundNumber}/` -> ex: `/ergast/f1/2024/5/driverstandings/`
+
+**Note**: To utilize the `round` parameter it must be combined with a season filter and needs to be the first route after `/ergast/f1/{season}/`
+
+---
+
 ### drivers
 
 **Filters for only for a specific driver's drivers standing information for a given year**

--- a/docs/endpoints/driverStandings.md
+++ b/docs/endpoints/driverStandings.md
@@ -5,7 +5,7 @@ Gets a season's drivers standings from first to last place.
 
 **URL** : `/ergast/f1/{season}/driverstandings/`
 
-[Available Query Parameters](docs/README.md#query-parameters)
+[Available Query Parameters](/docs/README.md#query-parameters)
 
 ---
 

--- a/docs/endpoints/driverStandings.md
+++ b/docs/endpoints/driverStandings.md
@@ -43,7 +43,7 @@ Gets a season's drivers standings
 
 **Filters for only the driver in a given position for a given year**
 
-`/{position}` -> ex: `/ergast/f1/2024/driverstandings/1/`
+`/{finishPosition}` -> ex: `/ergast/f1/2024/driverstandings/1/`
 
 **Note**: The position must be at the end after any filters and after `/driverstandings/`
 

--- a/docs/endpoints/driverStandings.md
+++ b/docs/endpoints/driverStandings.md
@@ -1,7 +1,7 @@
 [← Documentation Home](/docs/README.md)
 # Driver Standings
 
-Gets a season's drivers standings from first to last place. 
+Returns a season's drivers standings from first to last place. 
 
 **URL** : `/ergast/f1/{season}/driverstandings/`
 
@@ -9,31 +9,31 @@ Gets a season's drivers standings from first to last place.
 
 ---
 
-## Route Parameters:
+## Route Parameters
 
-### Season \*\*REQUIRED\*\*
+### Season (required)
 
-**Filters for the drivers standing of a specified season. Year numbers are valid as is `current` to get the current seasons drivers standings**
+Filters for the drivers standing of a specified season. Year numbers are valid as is `current` to get the current seasons drivers standings.
 
 `/{season}/` -> ex: `/ergast/f1/2024/driverstandings/`
 
-**Note**: To utilize the `season` parameter it needs to be the first route after `/ergast/f1/`
+**Note**: To utilize the `season` parameter, it needs to be the first argument after `/ergast/f1/`.
 
 ---
 
 ### Round
 
-**Filters for the drivers standings after a specified round in a specific season. Round numbers 1 -> n races are valid as well as `last`**
+Filters for the drivers standings after a specified round in a specific season. Round numbers 1 -> `n` races are valid as well as `last`.
 
 `/{season}/{round}/` -> ex: `/ergast/f1/2024/5/driverstandings/`
 
-**Note**: To utilize the `round` parameter it must be combined with a season filter and needs to be the first route after `/ergast/f1/{season}/`
+**Note**: To utilize the `round` parameter it must be combined with a season filter and needs to be the first argument after `/ergast/f1/{season}/`.
 
 ---
 
 ### drivers
 
-**Filters for only a specific driver's drivers standing information for a given year**
+Filters for only a specific driver's drivers standing information for a given year.
 
 `/drivers/{driverId}/` -> ex: `/ergast/f1/2024/drivers/hamilton/driverstandings/`
 
@@ -41,7 +41,7 @@ Gets a season's drivers standings from first to last place.
 
 ### position
 
-**Filters for only the driver in a given position for a given year**
+Filters for only the driver in a given position for a given year.
 
 `/{finishPosition}` -> ex: `/ergast/f1/2024/driverstandings/1/`
 

--- a/docs/endpoints/driverStandings.md
+++ b/docs/endpoints/driverStandings.md
@@ -75,12 +75,13 @@ Gets a season's drivers standings from first to last place.
 
 |Field|Required|
 |---|:---:|
-|position| ✅ |
+|position| ❌ |
 |positonText|✅|
 |points|✅|
 |wins|✅|
 |Driver|✅|
 |Constructors|✅|
+Possible values for positionText include: `E` Excluded, `D` Disqualified (1997 Schumacher), `-` for ineligible or the position as a string otherwise.  
 
 ---
 

--- a/docs/endpoints/driverStandings.md
+++ b/docs/endpoints/driverStandings.md
@@ -3,7 +3,7 @@
 
 Gets a season's drivers standings 
 
-**URL** : `/ergast/f1/{YEAR}/driverstandings/`
+**URL** : `/ergast/f1/{season}/driverstandings/`
 
 [Available Query Parameters](./README.md#query-parameters)
 

--- a/docs/endpoints/driverStandings.md
+++ b/docs/endpoints/driverStandings.md
@@ -75,7 +75,7 @@ Gets a season's drivers standings from first to last place.
 
 |Field|Required|
 |---|:---:|
-|position| ❌ |
+|position| 🟡 |
 |positonText|✅|
 |points|✅|
 |wins|✅|

--- a/docs/endpoints/driverStandings.md
+++ b/docs/endpoints/driverStandings.md
@@ -73,15 +73,16 @@ Gets a season's drivers standings from first to last place.
 
 ## Drivers Standing Object Fields:
 
-|Field|Always Included|
-|---|:---:|
-|position| 🟡 |
-|positonText|✅|
-|points|✅|
-|wins|✅|
-|Driver|✅|
-|Constructors|✅|
-Possible values for positionText include: `E` Excluded, `D` Disqualified (1997 Schumacher), `-` for ineligible or the position as a string otherwise.  
+|Field|Always Included|Description|type
+|---|:---:|---|---|
+|position|🟡|Position in the Championship|String
+|positonText|✅|Description of position `*`|String
+|points|✅|Total points in the Championship|String
+|wins|✅|Count of race wins|String
+|Driver|✅|Driver information (driverId, url, givenName, familyName, dateOfBirth, nationality)|Object
+|Constructors|✅|List of all constructors the driver drove for in the given season|Array
+
+`*` - Possible values for positionText include: `E` Excluded, `D` Disqualified (1997 Schumacher), `-` for ineligible or the position as a string otherwise.  
 
 ---
 

--- a/docs/endpoints/driverStandings.md
+++ b/docs/endpoints/driverStandings.md
@@ -1,0 +1,205 @@
+[← Documentation Home](/docs/README.md)
+# Driver Standings
+
+Gets a season's drivers standings 
+
+**URL** : `/ergast/f1/{YEAR}/driverstandings`
+
+[Available Query Parameters](./README.md#query-parameters)
+
+---
+
+## Route Parameters:
+
+### Season \*\*REQUIRED\*\*
+
+**Filters for the drivers' standing of a specified season. Year numbers are valid as is 'current' to get the current seasons drivers standings**
+
+`/{season}/` -> ex: `/ergast/f1/2024/driverstandings`
+
+**Note**: To utilize the `season` parameter it needs to be the first route after `/ergast/f1/`
+
+---
+
+### drivers
+
+**Filters for only for a specific driver's drivers standing information for a given year**
+
+`/drivers/{driverId}/` -> ex: `/ergast/f1/2024/drivers/hamilton/driverstandings`
+
+---
+
+### position
+
+**Filters for only for the driver in a given position for a given year**
+
+`/{position}` -> ex: `/ergast/f1/2024/driverstandings/1`
+
+**Note**: The position must be at the end after any filters and after `/driverstandings/`
+
+---
+
+## Success Response
+
+**Code** : `200 OK`
+
+**Response Fields** :
+
+[Common Response Fields](./README.md#common-response-fields)
+
+`MRData.StandingsTable` : The object containing the season's drivers standing information.
+
+`MRData.StandingsTable.season` : The filtered season.
+
+`MRData.StandingsTable.round` : The round that the season the standings represent.
+
+`MRData.StandingsTable.StandingsLists` : The list of drivers standings.
+
+`MRData.StandingsTable.StandingsLists[i]` : A given drivers standings list object.
+
+`MRData.StandingsTable.StandingsLists[i].DriverStandings` : The list of drivers standings objects.
+
+---
+
+## Drivers Standing Object Fields:
+
+|Field|Required|
+|---|:---:|
+|position| ✅ |
+|positonText|✅|
+|points|✅|
+|wins|✅|
+|Driver|✅|
+|Constructors|✅|
+
+---
+
+## Examples:
+
+### Get the 1972 season's drivers standing information
+
+`https://api.jolpi.ca/ergast/f1/1972/driverstandings`
+
+```json
+{
+  "MRData": {
+    "xmlns": "",
+    "series": "f1",
+    "url": "http://api.jolpi.ca/ergast/f1/1972/driverstandings/",
+    "limit": "30",
+    "offset": "0",
+    "total": "42",
+    "StandingsTable": {
+      "season": "1972",
+      "round": "12",
+      "StandingsLists": [
+        {
+          "season": "1972",
+          "round": "12",
+          "DriverStandings": [
+            {
+              "position": "1",
+              "positionText": "1",
+              "points": "61",
+              "wins": "5",
+              "Driver": {
+                "driverId": "emerson_fittipaldi",
+                "url": "http://en.wikipedia.org/wiki/Emerson_Fittipaldi",
+                "givenName": "Emerson",
+                "familyName": "Fittipaldi",
+                "dateOfBirth": "1946-12-12",
+                "nationality": "Brazilian"
+              },
+              "Constructors": [
+                {
+                  "constructorId": "team_lotus",
+                  "url": "http://en.wikipedia.org/wiki/Team_Lotus",
+                  "name": "Team Lotus",
+                  "nationality": "British"
+                }
+              ]
+            },
+            {
+              "position": "2",
+              "positionText": "2",
+              "points": "45",
+              "wins": "4",
+              "Driver": {
+                "driverId": "stewart",
+                "url": "http://en.wikipedia.org/wiki/Jackie_Stewart",
+                "givenName": "Jackie",
+                "familyName": "Stewart",
+                "dateOfBirth": "1939-06-11",
+                "nationality": "British"
+              },
+              "Constructors": [
+                {
+                  "constructorId": "tyrrell",
+                  "url": "http://en.wikipedia.org/wiki/Tyrrell_Racing",
+                  "name": "Tyrrell",
+                  "nationality": "British"
+                }
+              ]
+            },
+            ...more
+          ]
+        }
+      ]
+    }
+  }
+}
+```
+
+### Get Pierre Gasly's 2020 drivers standing information
+
+`http://api.jolpi.ca/ergast/f1/2020/drivers/gasly/driverstandings`
+
+```json
+{
+  "MRData": {
+    "xmlns": "",
+    "series": "f1",
+    "url": "http://api.jolpi.ca/ergast/f1/2020/drivers/gasly/driverstandings/",
+    "limit": "30",
+    "offset": "0",
+    "total": "1",
+    "StandingsTable": {
+      "season": "2020",
+      "driverId": "gasly",
+      "round": "17",
+      "StandingsLists": [
+        {
+          "season": "2020",
+          "round": "17",
+          "DriverStandings": [
+            {
+              "position": "10",
+              "positionText": "10",
+              "points": "75",
+              "wins": "1",
+              "Driver": {
+                "driverId": "gasly",
+                "permanentNumber": "10",
+                "code": "GAS",
+                "url": "http://en.wikipedia.org/wiki/Pierre_Gasly",
+                "givenName": "Pierre",
+                "familyName": "Gasly",
+                "dateOfBirth": "1996-02-07",
+                "nationality": "French"
+              },
+              "Constructors": [
+                {
+                  "constructorId": "alphatauri",
+                  "url": "http://en.wikipedia.org/wiki/Scuderia_AlphaTauri",
+                  "name": "AlphaTauri",
+                  "nationality": "Italian"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  }
+}
+```

--- a/docs/endpoints/driverStandings.md
+++ b/docs/endpoints/driverStandings.md
@@ -13,7 +13,7 @@ Gets a season's drivers standings
 
 ### Season \*\*REQUIRED\*\*
 
-**Filters for the drivers standing of a specified season. Year numbers are valid as is 'current' to get the current seasons drivers standings**
+**Filters for the drivers standing of a specified season. Year numbers are valid as is `current` to get the current seasons drivers standings**
 
 `/{season}/` -> ex: `/ergast/f1/2024/driverstandings/`
 
@@ -23,7 +23,7 @@ Gets a season's drivers standings
 
 ### Round
 
-**Filters for the drivers standings after a specified round in a specific season. Round numbers 1 -> n races are valid as well as 'last'**
+**Filters for the drivers standings after a specified round in a specific season. Round numbers 1 -> n races are valid as well as `last`**
 
 `/{season}/{roundNumber}/` -> ex: `/ergast/f1/2024/5/driverstandings/`
 

--- a/docs/endpoints/driverStandings.md
+++ b/docs/endpoints/driverStandings.md
@@ -25,7 +25,7 @@ Gets a season's drivers standings
 
 **Filters for the drivers standings after a specified round in a specific season. Round numbers 1 -> n races are valid as well as `last`**
 
-`/{season}/{roundNumber}/` -> ex: `/ergast/f1/2024/5/driverstandings/`
+`/{season}/{round}/` -> ex: `/ergast/f1/2024/5/driverstandings/`
 
 **Note**: To utilize the `round` parameter it must be combined with a season filter and needs to be the first route after `/ergast/f1/{season}/`
 

--- a/docs/endpoints/driverStandings.md
+++ b/docs/endpoints/driverStandings.md
@@ -33,7 +33,7 @@ Gets a season's drivers standings
 
 ### drivers
 
-**Filters for only for a specific driver's drivers standing information for a given year**
+**Filters for only a specific driver's drivers standing information for a given year**
 
 `/drivers/{driverId}/` -> ex: `/ergast/f1/2024/drivers/hamilton/driverstandings/`
 
@@ -41,7 +41,7 @@ Gets a season's drivers standings
 
 ### position
 
-**Filters for only for the driver in a given position for a given year**
+**Filters for only the driver in a given position for a given year**
 
 `/{position}` -> ex: `/ergast/f1/2024/driverstandings/1/`
 

--- a/docs/endpoints/driverStandings.md
+++ b/docs/endpoints/driverStandings.md
@@ -5,7 +5,7 @@ Gets a season's drivers standings from first to last place.
 
 **URL** : `/ergast/f1/{season}/driverstandings/`
 
-[Available Query Parameters](./README.md#query-parameters)
+[Available Query Parameters](docs/README.md#query-parameters)
 
 ---
 

--- a/docs/endpoints/driverStandings.md
+++ b/docs/endpoints/driverStandings.md
@@ -13,7 +13,7 @@ Gets a season's drivers standings
 
 ### Season \*\*REQUIRED\*\*
 
-**Filters for the drivers' standing of a specified season. Year numbers are valid as is 'current' to get the current seasons drivers standings**
+**Filters for the drivers standing of a specified season. Year numbers are valid as is 'current' to get the current seasons drivers standings**
 
 `/{season}/` -> ex: `/ergast/f1/2024/driverstandings/`
 

--- a/docs/endpoints/driverStandings.md
+++ b/docs/endpoints/driverStandings.md
@@ -3,7 +3,7 @@
 
 Gets a season's drivers standings 
 
-**URL** : `/ergast/f1/{YEAR}/driverstandings`
+**URL** : `/ergast/f1/{YEAR}/driverstandings/`
 
 [Available Query Parameters](./README.md#query-parameters)
 
@@ -15,7 +15,7 @@ Gets a season's drivers standings
 
 **Filters for the drivers' standing of a specified season. Year numbers are valid as is 'current' to get the current seasons drivers standings**
 
-`/{season}/` -> ex: `/ergast/f1/2024/driverstandings`
+`/{season}/` -> ex: `/ergast/f1/2024/driverstandings/`
 
 **Note**: To utilize the `season` parameter it needs to be the first route after `/ergast/f1/`
 
@@ -25,7 +25,7 @@ Gets a season's drivers standings
 
 **Filters for only for a specific driver's drivers standing information for a given year**
 
-`/drivers/{driverId}/` -> ex: `/ergast/f1/2024/drivers/hamilton/driverstandings`
+`/drivers/{driverId}/` -> ex: `/ergast/f1/2024/drivers/hamilton/driverstandings/`
 
 ---
 
@@ -33,7 +33,7 @@ Gets a season's drivers standings
 
 **Filters for only for the driver in a given position for a given year**
 
-`/{position}` -> ex: `/ergast/f1/2024/driverstandings/1`
+`/{position}` -> ex: `/ergast/f1/2024/driverstandings/1/`
 
 **Note**: The position must be at the end after any filters and after `/driverstandings/`
 
@@ -78,7 +78,7 @@ Gets a season's drivers standings
 
 ### Get the 1972 season's drivers standing information
 
-`https://api.jolpi.ca/ergast/f1/1972/driverstandings`
+`https://api.jolpi.ca/ergast/f1/1972/driverstandings/`
 
 ```json
 {
@@ -152,7 +152,7 @@ Gets a season's drivers standings
 
 ### Get Pierre Gasly's 2020 drivers standing information
 
-`http://api.jolpi.ca/ergast/f1/2020/drivers/gasly/driverstandings`
+`http://api.jolpi.ca/ergast/f1/2020/drivers/gasly/driverstandings/`
 
 ```json
 {

--- a/docs/endpoints/driverStandings.md
+++ b/docs/endpoints/driverStandings.md
@@ -1,7 +1,7 @@
 [← Documentation Home](/docs/README.md)
 # Driver Standings
 
-Gets a season's drivers standings 
+Gets a season's drivers standings from first to last place. 
 
 **URL** : `/ergast/f1/{season}/driverstandings/`
 

--- a/docs/endpoints/driverStandings.md
+++ b/docs/endpoints/driverStandings.md
@@ -73,7 +73,7 @@ Gets a season's drivers standings from first to last place.
 
 ## Drivers Standing Object Fields:
 
-|Field|Required|
+|Field|Always Included|
 |---|:---:|
 |position| 🟡 |
 |positonText|✅|

--- a/docs/endpoints/drivers.md
+++ b/docs/endpoints/drivers.md
@@ -21,6 +21,16 @@ Gets list of drivers
 
 ---
 
+### Round
+
+**Filters only drivers that participated in a specified round of a specific season. Round numbers 1 -> n races are valid as well as `last`**
+
+`/{round}/` -> ex: `/ergast/f1/2024/1/drivers/`
+
+**Note**: To utilize the `round` parameter it needs to be used with the `season` filter and be the first route after `/ergast/f1/{season}`
+
+---
+
 ### circuits
 
 **Filters for only drivers who have participated in a race at a given circuit**

--- a/docs/endpoints/drivers.md
+++ b/docs/endpoints/drivers.md
@@ -13,7 +13,7 @@ Gets list of drivers
 
 ### Season
 
-**Filters only drivers that participated in a specified season. Year numbers are valid as is 'current' to get the current season list of drivers**
+**Filters only drivers that participated in a specified season. Year numbers are valid as is `current` to get the current season list of drivers**
 
 `/{season}/` -> ex: `/ergast/f1/2024/drivers/`
 

--- a/docs/endpoints/drivers.md
+++ b/docs/endpoints/drivers.md
@@ -5,7 +5,7 @@ Gets list of drivers in alphabetical order by driverId
 
 **URL** : `/ergast/f1/drivers/`
 
-[Available Query Parameters](docs/README.md#query-parameters)
+[Available Query Parameters](/docs/README.md#query-parameters)
 
 ---
 

--- a/docs/endpoints/drivers.md
+++ b/docs/endpoints/drivers.md
@@ -107,16 +107,16 @@ Gets list of drivers in alphabetical order by driverId
 
 ## Driver Object Fields:
 
-|Field|Always Included|
-|---|:---:|
-|driverId| ✅ |
-|permanentNumber|🟡|
-|code|🟡|
-|url|✅|
-|givenName|✅|
-|familyName|✅|
-|dateOfBirth|✅|
-|nationality|✅|
+|Field|Always Included|Description|type
+|---|:---:|---|---|
+|driverId|✅|Unique ID of the Driver|String
+|permanentNumber|🟡|Permanent Number assigned to the driver|String
+|code|🟡|Driver Code, usually 3 characters|String
+|url|✅|Wikipedia URL to the Drivers profile|String
+|givenName|✅|First name|String
+|familyName|✅|Last name|String
+|dateOfBirth|✅|Date of Birth (YYYY-MM-DD format)|String
+|nationality|✅|Nationality of Driver|String
 
 ---
 

--- a/docs/endpoints/drivers.md
+++ b/docs/endpoints/drivers.md
@@ -1,7 +1,7 @@
 [← Documentation Home](/docs/README.md)
 # Drivers
 
-Returns list of drivers in alphabetical order by `driverId`
+Returns a list of drivers in alphabetical order by `driverId`
 
 **URL** : `/ergast/f1/drivers/`
 

--- a/docs/endpoints/drivers.md
+++ b/docs/endpoints/drivers.md
@@ -3,7 +3,7 @@
 
 Gets list of drivers 
 
-**URL** : `/ergast/f1/drivers`
+**URL** : `/ergast/f1/drivers/`
 
 [Available Query Parameters](./README.md#query-parameters)
 
@@ -15,7 +15,7 @@ Gets list of drivers
 
 **Filters only drivers that participated in a specified season. Year numbers are valid as is 'current' to get the current season list of drivers**
 
-`/{season}/` -> ex: `/ergast/f1/2024/drivers`
+`/{season}/` -> ex: `/ergast/f1/2024/drivers/`
 
 **Note**: To utilize the `season` parameter it needs to be the first route after `/ergast/f1/`
 
@@ -25,7 +25,7 @@ Gets list of drivers
 
 **Filters for only drivers who have participated in a race at a given circuit**
 
-`/circuits/{circuitId}/` -> ex: `/ergast/f1/2024/circuits/albert_park/drivers`
+`/circuits/{circuitId}/` -> ex: `/ergast/f1/2024/circuits/albert_park/drivers/`
 
 ---
 
@@ -33,7 +33,7 @@ Gets list of drivers
 
 **Filters for only drivers who have raced for a specified constructor**
 
-`/constructors/{constructorId}/` -> ex: `/ergast/f1/constructors/williams/drivers`
+`/constructors/{constructorId}/` -> ex: `/ergast/f1/constructors/williams/drivers/`
 
 ---
 
@@ -41,7 +41,7 @@ Gets list of drivers
 
 **Filters for only drivers that match the specific driverId**
 
-`/drivers/{driverId}/` -> ex: `/ergast/f1/drivers/hamilton/drivers`
+`/drivers/{driverId}/` -> ex: `/ergast/f1/drivers/hamilton/drivers/`
 
 
 ---
@@ -50,7 +50,7 @@ Gets list of drivers
 
 **Filters for only drivers that finished a race with a lap that was the ranked in the specified position**
 
-`/fastest/{lapRank}/` -> ex: `/ergast/f1/fastest/1/drivers`
+`/fastest/{lapRank}/` -> ex: `/ergast/f1/fastest/1/drivers/`
 
 
 ---
@@ -59,7 +59,7 @@ Gets list of drivers
 
 **Filters for only drivers who has started a race in a specific grid position**
 
-`/grid/{gridPosition}/` -> ex: `/ergast/f1/grid/1/drivers`
+`/grid/{gridPosition}/` -> ex: `/ergast/f1/grid/1/drivers/`
 
 ---
 
@@ -67,7 +67,7 @@ Gets list of drivers
 
 **Filters for only drivers who has finished a race in a specific position**
 
-`/results/{position}/` -> ex: `/ergast/f1/results/1/drivers`
+`/results/{position}/` -> ex: `/ergast/f1/results/1/drivers/`
 
 ---
 
@@ -75,7 +75,7 @@ Gets list of drivers
 
 **Filters for only drivers who have finished a race with a specific statusId**
 
-`/status/{statusId}/` -> ex: `/ergast/f1/status/2/drivers`
+`/status/{statusId}/` -> ex: `/ergast/f1/status/2/drivers/`
 
 ---
 
@@ -114,7 +114,7 @@ Gets list of drivers
 
 ### Get list of all drivers in F1 history
 
-`https://api.jolpi.ca/ergast/f1/drivers`
+`https://api.jolpi.ca/ergast/f1/drivers/`
 
 ```json
 {
@@ -154,7 +154,7 @@ Gets list of drivers
 
 * Note this is missing Logan Sargent as he did not start the race even though he participated in the weekend.
 
-`https://api.jolpi.ca/ergast/f1/2024/circuits/albert_park/drivers`
+`https://api.jolpi.ca/ergast/f1/2024/circuits/albert_park/drivers/`
 
 ```json
 {

--- a/docs/endpoints/drivers.md
+++ b/docs/endpoints/drivers.md
@@ -5,7 +5,7 @@ Gets list of drivers in alphabetical order by driverId
 
 **URL** : `/ergast/f1/drivers/`
 
-[Available Query Parameters](./README.md#query-parameters)
+[Available Query Parameters](docs/README.md#query-parameters)
 
 ---
 

--- a/docs/endpoints/drivers.md
+++ b/docs/endpoints/drivers.md
@@ -51,7 +51,7 @@ Gets list of drivers in alphabetical order by driverId
 
 **Filters for only drivers that match the specific driverId**
 
-`/drivers/{driverId}/` -> ex: `/ergast/f1/drivers/hamilton/drivers/`
+`/drivers/{driverId}/` -> ex: `/ergast/f1/drivers/hamilton/`
 
 
 ---

--- a/docs/endpoints/drivers.md
+++ b/docs/endpoints/drivers.md
@@ -110,8 +110,8 @@ Gets list of drivers in alphabetical order by driverId
 |Field|Required|
 |---|:---:|
 |driverId| ✅ |
-|permanentNumber|❌|
-|code|❌|
+|permanentNumber|🟡|
+|code|🟡|
 |url|✅|
 |givenName|✅|
 |familyName|✅|

--- a/docs/endpoints/drivers.md
+++ b/docs/endpoints/drivers.md
@@ -67,7 +67,7 @@ Gets list of drivers
 
 **Filters for only drivers who has finished a race in a specific position**
 
-`/results/{position}/` -> ex: `/ergast/f1/results/1/drivers/`
+`/results/{finishPosition}/` -> ex: `/ergast/f1/results/1/drivers/`
 
 ---
 

--- a/docs/endpoints/drivers.md
+++ b/docs/endpoints/drivers.md
@@ -107,7 +107,7 @@ Gets list of drivers in alphabetical order by driverId
 
 ## Driver Object Fields:
 
-|Field|Required|
+|Field|Always Included|
 |---|:---:|
 |driverId| ✅ |
 |permanentNumber|🟡|

--- a/docs/endpoints/drivers.md
+++ b/docs/endpoints/drivers.md
@@ -1,7 +1,7 @@
 [← Documentation Home](/docs/README.md)
 # Drivers
 
-Gets list of drivers 
+Gets list of drivers in alphabetical order by driverId
 
 **URL** : `/ergast/f1/drivers/`
 

--- a/docs/endpoints/drivers.md
+++ b/docs/endpoints/drivers.md
@@ -112,11 +112,11 @@ Filters for only drivers who have finished a race with a specific `statusId`.
 |driverId|✅|Unique ID of the Driver|String
 |permanentNumber|🟡|Permanent Number assigned to the driver|String
 |code|🟡|Driver Code, usually 3 characters|String
-|url|✅|Wikipedia URL to the Drivers profile|String
+|url| 🟡 |Wikipedia URL to the Drivers profile|String
 |givenName|✅|First name|String
 |familyName|✅|Last name|String
-|dateOfBirth|✅|Date of Birth (YYYY-MM-DD format)|String
-|nationality|✅|Nationality of Driver|String
+|dateOfBirth| 🟡 |Date of Birth (YYYY-MM-DD format)|String
+|nationality| 🟡 |Nationality of Driver|String
 
 ---
 

--- a/docs/endpoints/drivers.md
+++ b/docs/endpoints/drivers.md
@@ -1,7 +1,7 @@
 [← Documentation Home](/docs/README.md)
 # Drivers
 
-Gets list of drivers in alphabetical order by driverId
+Returns list of drivers in alphabetical order by `driverId`
 
 **URL** : `/ergast/f1/drivers/`
 
@@ -9,31 +9,31 @@ Gets list of drivers in alphabetical order by driverId
 
 ---
 
-## Route Parameters:
+## Route Parameters
 
 ### Season
 
-**Filters only drivers that participated in a specified season. Year numbers are valid as is `current` to get the current season list of drivers**
+Filters only drivers that participated in a specified season. Year numbers are valid as is `current` to get the current season list of drivers.
 
 `/{season}/` -> ex: `/ergast/f1/2024/drivers/`
 
-**Note**: To utilize the `season` parameter it needs to be the first route after `/ergast/f1/`
+**Note**: To utilize the `season` parameter, it needs to be the first argument after `/ergast/f1/`.
 
 ---
 
 ### Round
 
-**Filters only drivers that participated in a specified round of a specific season. Round numbers 1 -> n races are valid as well as `last`**
+Filters only drivers that participated in a specified round of a specific season. Round numbers 1 -> `n` races are valid as well as `last`.
 
 `/{round}/` -> ex: `/ergast/f1/2024/1/drivers/`
 
-**Note**: To utilize the `round` parameter it needs to be used with the `season` filter and be the first route after `/ergast/f1/{season}`
+**Note**: **Note**: To utilize the `round` parameter it needs to be used with the `season` filter and be the first argument after `/ergast/f1/{season}`.
 
 ---
 
 ### circuits
 
-**Filters for only drivers who have participated in a race at a given circuit**
+Filters for only drivers who have participated in a race at a given circuit.
 
 `/circuits/{circuitId}/` -> ex: `/ergast/f1/2024/circuits/albert_park/drivers/`
 
@@ -41,7 +41,7 @@ Gets list of drivers in alphabetical order by driverId
 
 ### constructors
 
-**Filters for only drivers who have raced for a specified constructor**
+Filters for only drivers who have raced for a specified constructor.
 
 `/constructors/{constructorId}/` -> ex: `/ergast/f1/constructors/williams/drivers/`
 
@@ -49,7 +49,7 @@ Gets list of drivers in alphabetical order by driverId
 
 ### drivers
 
-**Filters for only drivers that match the specific driverId**
+Filters for only drivers that match the specific `driverId`.
 
 `/drivers/{driverId}/` -> ex: `/ergast/f1/drivers/hamilton/`
 
@@ -58,7 +58,7 @@ Gets list of drivers in alphabetical order by driverId
 
 ### fastest
 
-**Filters for only drivers that finished a race with a lap that was the ranked in the specified position**
+Filters for only drivers that finished a race with a lap that was the ranked in the specified position.
 
 `/fastest/{lapRank}/` -> ex: `/ergast/f1/fastest/1/drivers/`
 
@@ -67,7 +67,7 @@ Gets list of drivers in alphabetical order by driverId
 
 ### grid
 
-**Filters for only drivers who has started a race in a specific grid position**
+Filters for only drivers who have started a race in a specific grid position.
 
 `/grid/{gridPosition}/` -> ex: `/ergast/f1/grid/1/drivers/`
 
@@ -75,7 +75,7 @@ Gets list of drivers in alphabetical order by driverId
 
 ### results
 
-**Filters for only drivers who has finished a race in a specific position**
+Filters for only drivers who have finished a race in a specific position.
 
 `/results/{finishPosition}/` -> ex: `/ergast/f1/results/1/drivers/`
 
@@ -83,7 +83,7 @@ Gets list of drivers in alphabetical order by driverId
 
 ### status
 
-**Filters for only drivers who have finished a race with a specific statusId**
+Filters for only drivers who have finished a race with a specific `statusId`.
 
 `/status/{statusId}/` -> ex: `/ergast/f1/status/2/drivers/`
 
@@ -101,7 +101,7 @@ Gets list of drivers in alphabetical order by driverId
 
 `MRData.DriverTable.Drivers` : The list of all drivers returned.
 
-`MRData.DriverTable.Drivers[i]` : A given driver object
+`MRData.DriverTable.Drivers[i]` : A given driver object.
 
 ---
 

--- a/docs/endpoints/pitstops.md
+++ b/docs/endpoints/pitstops.md
@@ -7,7 +7,7 @@ Gets a given races list of pitstops in from earliest to latest `time` in which t
 
 **URL** : `/ergast/f1/{season}/{ROUND}/pitstops/`
 
-[Available Query Parameters](./README.md#query-parameters)
+[Available Query Parameters](docs/README.md#query-parameters)
 
 ---
 

--- a/docs/endpoints/pitstops.md
+++ b/docs/endpoints/pitstops.md
@@ -86,10 +86,10 @@ Gets a given races list of pitstops in from earliest to latest `time` in which t
 |Field|Required|
 |---|:---:|
 |driverId| ✅ |
-|lap|✅|
-|stop|✅|
-|time|✅|
-|duration|✅|
+|lap|🟡|
+|stop|🟡|
+|time|🟡|
+|duration|🟡|
 
 ---
 

--- a/docs/endpoints/pitstops.md
+++ b/docs/endpoints/pitstops.md
@@ -1,7 +1,9 @@
 [← Documentation Home](/docs/README.md)
 # Pitstops Standings
 
-Gets a given races list of pitstops. Data starts for the 2011 season
+Gets a given races list of pitstops in from earliest to latest `time` in which the pitstop occurred.
+
+**Note**: Data starts for the 2011 season.
 
 **URL** : `/ergast/f1/{season}/{ROUND}/pitstops/`
 

--- a/docs/endpoints/pitstops.md
+++ b/docs/endpoints/pitstops.md
@@ -1,7 +1,7 @@
 [← Documentation Home](/docs/README.md)
 # Pitstops Standings
 
-Gets a given races list of pitstops in from earliest to latest `time` in which the pitstop occurred.
+Returns a given races list of pitstops, from earliest to latest `time` in which the pitstop occurred.
 
 **Note**: Data starts for the 2011 season.
 
@@ -11,31 +11,31 @@ Gets a given races list of pitstops in from earliest to latest `time` in which t
 
 ---
 
-## Route Parameters:
+## Route Parameters
 
-### Season \*\*REQUIRED\*\*
+### Season (required)
 
-**Filters for the season that the list of pitstops will be from. Year numbers are valid as is `current` to get the pitstops of a given round in the current season**
+Filters for the season that the list of pitstops will be from. Year numbers are valid as is `current` to get the pitstops of a given round in the current season.
 
 `/{season}/` -> ex: `/ergast/f1/2024/1/pitstops/`
 
-**Note**: To utilize the `season` parameter it needs to be the first route after `/ergast/f1/`
+**Note**: To utilize the `season` parameter, it needs to be the first argument after `/ergast/f1/`.
 
 ---
 
-### Round \*\*REQUIRED\*\*
+### Round (required)
 
-**Filters for the round in a specific season that the list of pitstops will be from. Round numbers 1 -> n races are valid as well as `last`**
+Filters for the round in a specific season that the list of pitstops will be from. Round numbers 1 -> `n` races are valid as well as `last`.
 
 `/{season}/{round}/` -> ex: `/ergast/f1/2024/5/pitstops/`
 
-**Note**: To utilize the `round` parameter it must be combined with a season filter and needs to be the first route after `/ergast/f1/{season}/`
+**Note**: To utilize the `round` parameter it must be combined with a season filter and needs to be the first argument after `/ergast/f1/{season}/`.
 
 ---
 
 ### drivers
 
-**Filters for only for a specific drivers's list of pitstops in a seasons round**
+Filters for only for a specific drivers's list of pitstops in a season's round.
 
 `/drivers/{driversId}/` -> ex: `/ergast/f1/2024/1/drivers/hamilton/pitstops/`
 
@@ -43,7 +43,7 @@ Gets a given races list of pitstops in from earliest to latest `time` in which t
 
 ### laps
 
-**Filters for only pitstops that took place in a given lap of a race**
+Filters for only pitstops that took place in a given lap of a race.
 
 `/laps/{lapNumber}` -> ex: `/ergast/f1/2019/4/laps/12/pitstops`
 
@@ -163,7 +163,7 @@ Gets a given races list of pitstops in from earliest to latest `time` in which t
 
 ### Get all of Fernando Alonso's pitstops in the 2023 Dutch Grand Prix
 
-`http://api.jolpi.ca/ergast/f1/2023/13/drivers/alonso/pitstops//`
+`http://api.jolpi.ca/ergast/f1/2023/13/drivers/alonso/pitstops/`
 
 ```json
 {

--- a/docs/endpoints/pitstops.md
+++ b/docs/endpoints/pitstops.md
@@ -83,7 +83,7 @@ Gets a given races list of pitstops in from earliest to latest `time` in which t
 
 ## Pitstops Object Fields:
 
-|Field|Required|
+|Field|Always Included|
 |---|:---:|
 |driverId| ✅ |
 |lap|🟡|

--- a/docs/endpoints/pitstops.md
+++ b/docs/endpoints/pitstops.md
@@ -3,7 +3,7 @@
 
 Gets a given races list of pitstops. Data starts for the 2011 season
 
-**URL** : `/ergast/f1/{YEAR}/{ROUND}/pitstops/`
+**URL** : `/ergast/f1/{season}/{ROUND}/pitstops/`
 
 [Available Query Parameters](./README.md#query-parameters)
 

--- a/docs/endpoints/pitstops.md
+++ b/docs/endpoints/pitstops.md
@@ -1,0 +1,240 @@
+[← Documentation Home](/docs/README.md)
+# Pitstops Standings
+
+Gets a given races list of pitstops. Data starts for the 2011 season
+
+**URL** : `/ergast/f1/{YEAR}/{ROUND}/pitstops/`
+
+[Available Query Parameters](./README.md#query-parameters)
+
+---
+
+## Route Parameters:
+
+### Season \*\*REQUIRED\*\*
+
+**Filters for the season that the list of pitstops will be from. Year numbers are valid as is 'current' to get the pitstops of a given round in the current season**
+
+`/{season}/` -> ex: `/ergast/f1/2024/1/pitstops/`
+
+**Note**: To utilize the `season` parameter it needs to be the first route after `/ergast/f1/`
+
+---
+
+### Round \*\*REQUIRED\*\*
+
+**Filters for the round in a specific season that the list of pitstops will be from. Round numbers 1 -> n races are valid as well as 'last'**
+
+`/{season}/{roundNumber}/` -> ex: `/ergast/f1/2024/5/pitstops/`
+
+**Note**: To utilize the `round` parameter it must be combined with a season filter and needs to be the first route after `/ergast/f1/{season}/`
+
+---
+
+### drivers
+
+**Filters for only for a specific drivers's list of pitstops in a seasons round**
+
+`/drivers/{driversId}/` -> ex: `/ergast/f1/2024/1/drivers/hamilton/pitstops/`
+
+---
+
+### laps
+
+**Filters for only pitstops that took place in a given lap of a race**
+
+`/laps/{lapNumber}` -> ex: `/ergast/f1/2019/4/laps/12/pitstops`
+
+---
+
+## Success Response
+
+**Code** : `200 OK`
+
+**Response Fields** :
+
+[Common Response Fields](./README.md#common-response-fields)
+
+`MRData.RaceTable` : The object containing the pitstops information.
+
+`MRData.RaceTable.season` : The filtered season.
+
+`MRData.RaceTable.round` : The filtered round.
+
+`MRData.RaceTable.url` : The race's wikipedia url.
+
+`MRData.RaceTable.raceName` : The race's name.
+
+`MRData.RaceTable.Circuit` : The circuit of the race.
+
+`MRData.RaceTable.date` : The date of the race.
+
+`MRData.RaceTable.time` : The time of the race.
+
+`MRData.RaceTable.Races` : The list of races.
+
+`MRData.RaceTable.Races[i]` : A given race's object.
+
+`MRData.RaceTable.Races[i].Pitstops` : The list of pitstops in a given race.
+
+---
+
+## Pitstops Object Fields:
+
+|Field|Required|
+|---|:---:|
+|driverId| ✅ |
+|lap|✅|
+|stop|✅|
+|time|✅|
+|duration|✅|
+
+---
+
+## Examples:
+
+### Get the 4th round of the 2019 season's list of pitstops
+
+`http://api.jolpi.ca/ergast/f1/2019/4/laps/12/pitstops/`
+
+```json
+{
+  "MRData": {
+    "xmlns": "",
+    "series": "f1",
+    "url": "http://api.jolpi.ca/ergast/f1/2019/4/laps/12/pitstops/",
+    "limit": "30",
+    "offset": "0",
+    "total": "3",
+    "RaceTable": {
+      "season": "2019",
+      "round": "4",
+      "lap": "12",
+      "Races": [
+        {
+          "season": "2019",
+          "round": "4",
+          "url": "http://en.wikipedia.org/wiki/2019_Azerbaijan_Grand_Prix",
+          "raceName": "Azerbaijan Grand Prix",
+          "Circuit": {
+            "circuitId": "baku",
+            "url": "http://en.wikipedia.org/wiki/Baku_City_Circuit",
+            "circuitName": "Baku City Circuit",
+            "Location": {
+              "lat": "40.3725",
+              "long": "49.8533",
+              "locality": "Baku",
+              "country": "Azerbaijan"
+            }
+          },
+          "date": "2019-04-28",
+          "time": "12:10:00Z",
+          "PitStops": [
+            {
+              "driverId": "bottas",
+              "lap": "12",
+              "stop": "1",
+              "time": "16:35:24",
+              "duration": "20.006"
+            },
+            {
+              "driverId": "sainz",
+              "lap": "12",
+              "stop": "1",
+              "time": "16:35:58",
+              "duration": "19.755"
+            },
+            {
+              "driverId": "albon",
+              "lap": "12",
+              "stop": "1",
+              "time": "16:36:16",
+              "duration": "20.720"
+            }
+          ]
+        }
+      ]
+    }
+  }
+}
+```
+
+### Get all of Fernando Alonso's pitstops in the 2023 Dutch Grand Prix
+
+`http://api.jolpi.ca/ergast/f1/2023/13/drivers/alonso/pitstops//`
+
+```json
+{
+  "MRData": {
+    "xmlns": "",
+    "series": "f1",
+    "url": "http://api.jolpi.ca/ergast/f1/2023/13/drivers/alonso/pitstops/",
+    "limit": "30",
+    "offset": "0",
+    "total": "5",
+    "RaceTable": {
+      "season": "2023",
+      "round": "13",
+      "driverId": "alonso",
+      "Races": [
+        {
+          "season": "2023",
+          "round": "13",
+          "url": "https://en.wikipedia.org/wiki/2023_Dutch_Grand_Prix",
+          "raceName": "Dutch Grand Prix",
+          "Circuit": {
+            "circuitId": "zandvoort",
+            "url": "http://en.wikipedia.org/wiki/Circuit_Zandvoort",
+            "circuitName": "Circuit Park Zandvoort",
+            "Location": {
+              "lat": "52.3888",
+              "long": "4.54092",
+              "locality": "Zandvoort",
+              "country": "Netherlands"
+            }
+          },
+          "date": "2023-08-27",
+          "time": "13:00:00Z",
+          "PitStops": [
+            {
+              "driverId": "alonso",
+              "lap": "2",
+              "stop": "1",
+              "time": "15:06:26",
+              "duration": "20.647"
+            },
+            {
+              "driverId": "alonso",
+              "lap": "10",
+              "stop": "2",
+              "time": "15:18:10",
+              "duration": "20.109"
+            },
+            {
+              "driverId": "alonso",
+              "lap": "48",
+              "stop": "3",
+              "time": "16:10:51",
+              "duration": "25.147"
+            },
+            {
+              "driverId": "alonso",
+              "lap": "61",
+              "stop": "4",
+              "time": "16:27:35",
+              "duration": "20.655"
+            },
+            {
+              "driverId": "alonso",
+              "lap": "64",
+              "stop": "5",
+              "time": "16:33:22",
+              "duration": "40:55.302"
+            }
+          ]
+        }
+      ]
+    }
+  }
+}
+```

--- a/docs/endpoints/pitstops.md
+++ b/docs/endpoints/pitstops.md
@@ -83,13 +83,13 @@ Gets a given races list of pitstops in from earliest to latest `time` in which t
 
 ## Pitstops Object Fields:
 
-|Field|Always Included|
-|---|:---:|
-|driverId| ✅ |
-|lap|🟡|
-|stop|🟡|
-|time|🟡|
-|duration|🟡|
+|Field|Always Included|Description|type
+|---|:---:|---|---|
+|driverId|✅|Unique ID of the driver|String
+|lap|🟡|Lap Identifier|String
+|stop|🟡|Stop number for this driver in the race|String
+|time|🟡|Time that the stop occurred (HH:mm:ss)|String
+|duration|🟡|Duration of the stop, including pit entry, exit and red flag time, if necessary (MM:ss.sss)|String
 
 ---
 

--- a/docs/endpoints/pitstops.md
+++ b/docs/endpoints/pitstops.md
@@ -25,7 +25,7 @@ Gets a given races list of pitstops. Data starts for the 2011 season
 
 **Filters for the round in a specific season that the list of pitstops will be from. Round numbers 1 -> n races are valid as well as `last`**
 
-`/{season}/{roundNumber}/` -> ex: `/ergast/f1/2024/5/pitstops/`
+`/{season}/{round}/` -> ex: `/ergast/f1/2024/5/pitstops/`
 
 **Note**: To utilize the `round` parameter it must be combined with a season filter and needs to be the first route after `/ergast/f1/{season}/`
 

--- a/docs/endpoints/pitstops.md
+++ b/docs/endpoints/pitstops.md
@@ -7,7 +7,7 @@ Gets a given races list of pitstops in from earliest to latest `time` in which t
 
 **URL** : `/ergast/f1/{season}/{ROUND}/pitstops/`
 
-[Available Query Parameters](docs/README.md#query-parameters)
+[Available Query Parameters](/docs/README.md#query-parameters)
 
 ---
 

--- a/docs/endpoints/pitstops.md
+++ b/docs/endpoints/pitstops.md
@@ -13,7 +13,7 @@ Gets a given races list of pitstops. Data starts for the 2011 season
 
 ### Season \*\*REQUIRED\*\*
 
-**Filters for the season that the list of pitstops will be from. Year numbers are valid as is 'current' to get the pitstops of a given round in the current season**
+**Filters for the season that the list of pitstops will be from. Year numbers are valid as is `current` to get the pitstops of a given round in the current season**
 
 `/{season}/` -> ex: `/ergast/f1/2024/1/pitstops/`
 
@@ -23,7 +23,7 @@ Gets a given races list of pitstops. Data starts for the 2011 season
 
 ### Round \*\*REQUIRED\*\*
 
-**Filters for the round in a specific season that the list of pitstops will be from. Round numbers 1 -> n races are valid as well as 'last'**
+**Filters for the round in a specific season that the list of pitstops will be from. Round numbers 1 -> n races are valid as well as `last`**
 
 `/{season}/{roundNumber}/` -> ex: `/ergast/f1/2024/5/pitstops/`
 

--- a/docs/endpoints/qualifying.md
+++ b/docs/endpoints/qualifying.md
@@ -1,7 +1,7 @@
 [← Documentation Home](/docs/README.md)
 # Qualifying
 
-Gets list of qualification results from each race.
+Returns list of qualification results from each race.
 
 **URL** : `/ergast/f1/qualifying/`
 
@@ -9,31 +9,31 @@ Gets list of qualification results from each race.
 
 ---
 
-## Route Parameters:
+## Route Parameters
 
 ### Season
 
-**Filters for qualifying results only from a specified season. Year numbers are valid as is `current` to get the current season**
+Filters for qualifying results only from a specified season. Year numbers are valid as is `current` to get the current season.
 
 `/{season}/` -> ex: `/ergast/f1/2024/qualifying/`
 
-**Note**: To utilize the `season` parameter it needs to be the first route after `/ergast/f1/`
+**Note**: To utilize the `season` parameter, it needs to be the first argument after `/ergast/f1/`.
 
 ---
 
 ### Round
 
-**Filters for the qualifying results for a specified round in a specific season. Round numbers 1 -> n races are valid as well as `last` and `next`**
+Filters for the qualifying results for a specified round in a specific season. Round numbers 1 -> `n` races are valid as well as `last` and `next`.
 
 `/{season}/{round}/` -> ex: `/ergast/f1/2024/5/qualifying/`
 
-**Note**: To utilize the `round` parameter it must be combined with a season filter and needs to be the first route after `/ergast/f1/{season}/`
+**Note**: To utilize the `round` parameter it must be combined with a season filter and needs to be the first argument after `/ergast/f1/{season}/`.
 
 ---
 
 ### circuits
 
-**Filters for the qualifying results at a specified circuit**
+Filters for the qualifying results at a specified circuit.
 
 `/circuits/{circuitId}/` -> ex: `/ergast/f1/circuits/monza/qualifying/`
 
@@ -41,7 +41,7 @@ Gets list of qualification results from each race.
 
 ### constructors
 
-**Filters for the qualifying results of drivers driving for a specified constructor**
+Filters for the qualifying results of drivers driving for a specified constructor.
 
 `/constructors/{constructorId}/` -> ex: `/ergast/f1/constructors/williams/qualifying/`
 
@@ -49,7 +49,7 @@ Gets list of qualification results from each race.
 
 ### drivers
 
-**Filters for the qualifying results of a specified driver**
+Filters for the qualifying results of a specified driver.
 
 `/drivers/{driverId}/` -> ex: `/ergast/f1/drivers/hamilton/qualifying/`
 
@@ -57,7 +57,7 @@ Gets list of qualification results from each race.
 
 ### grid
 
-**Filters for the qualifying results of a driver who started the associated race in a specified grid position**
+Filters for the qualifying results of a driver who started the associated race in a specified grid position.
 
 `/grid/{gridPosition}/` -> ex: `/ergast/f1/grid/18/qualifying/`
 
@@ -67,7 +67,7 @@ Gets list of qualification results from each race.
 
 ### fastest
 
-**Filters for the qualifying results a driver with the fastest lap rank at a given Grand Prix**
+Filters for the qualifying results a driver with the fastest lap rank at a given Grand Prix.
 
 `/fastest/{lapRank}/` -> ex: `/ergast/f1/fastest/2/qualifying/`
 
@@ -77,7 +77,7 @@ Gets list of qualification results from each race.
 
 ### status
 
-**Filters for the qualifying results of any drivers with the finishing statusId at a given Grand Prix**
+Filters for the qualifying results of any drivers with the finishing statusId at a given Grand Prix.
 
 `/status/{statusId}/` -> ex: `/ergast/f1/status/11/qualifying/`
 

--- a/docs/endpoints/qualifying.md
+++ b/docs/endpoints/qualifying.md
@@ -108,7 +108,7 @@ Filters for the qualifying results of any drivers with the finishing statusId at
 |Field|Always Included|Description|type
 |---|:---:|---|---|
 |number|✅|Driver's car number|String
-|position|✅|Qualifying Result Position|String
+|position| 🟡 |Qualifying Result Position|String
 |Driver|✅|Driver information (driverId, permanentNumber, code, url, givenName, familyName, dateOfBirth, nationality)|Object
 |Constructor|✅|Constructor information (constructorId, url, name, nationality)|Object
 |Q1|🟡|Qualifying 1 Result (mm:ss.sss)|String

--- a/docs/endpoints/qualifying.md
+++ b/docs/endpoints/qualifying.md
@@ -1,7 +1,7 @@
 [← Documentation Home](/docs/README.md)
 # Qualifying
 
-Returns list of qualification results from each race.
+Returns a list of qualification results from each race.
 
 **URL** : `/ergast/f1/qualifying/`
 

--- a/docs/endpoints/qualifying.md
+++ b/docs/endpoints/qualifying.md
@@ -1,0 +1,301 @@
+[← Documentation Home](/docs/README.md)
+# Qualifying
+
+Gets list of qualification results from each race.
+
+**URL** : `/ergast/f1/qualifying/`
+
+[Available Query Parameters](/docs/README.md#query-parameters)
+
+---
+
+## Route Parameters:
+
+### Season
+
+**Filters for qualifying results only from a specified season. Year numbers are valid as is `current` to get the current season**
+
+`/{season}/` -> ex: `/ergast/f1/2024/qualifying/`
+
+**Note**: To utilize the `season` parameter it needs to be the first route after `/ergast/f1/`
+
+---
+
+### Round
+
+**Filters for the qualifying results for a specified round in a specific season. Round numbers 1 -> n races are valid as well as `last` and `next`**
+
+`/{season}/{round}/` -> ex: `/ergast/f1/2024/5/qualifying/`
+
+**Note**: To utilize the `round` parameter it must be combined with a season filter and needs to be the first route after `/ergast/f1/{season}/`
+
+---
+
+### circuits
+
+**Filters for the qualifying results at a specified circuit**
+
+`/circuits/{circuitId}/` -> ex: `/ergast/f1/circuits/monza/qualifying/`
+
+---
+
+### constructors
+
+**Filters for the qualifying results of drivers driving for a specified constructor**
+
+`/constructors/{constructorId}/` -> ex: `/ergast/f1/constructors/williams/qualifying/`
+
+---
+
+### drivers
+
+**Filters for the qualifying results of a specified driver**
+
+`/drivers/{driverId}/` -> ex: `/ergast/f1/drivers/hamilton/qualifying/`
+
+---
+
+### grid
+
+**Filters for the qualifying results of a driver who started the associated race in a specified grid position**
+
+`/grid/{gridPosition}/` -> ex: `/ergast/f1/grid/18/qualifying/`
+
+**Example**: Pierre Gasly finished Qualifying in 13th for the 2024 Azerbaijan Grand Prix but was disqualified due to instantaneous fuel mass flow limit and started P18 after Ocon and Hamilton. So `/ergast/f1/2024/17/grid/18/qualifying/` would return Gasly's results instead of Zhou who finished Qualifying in P18.
+
+---
+
+### fastest
+
+**Filters for the qualifying results a driver with the fastest lap rank at a given Grand Prix**
+
+`/fastest/{lapRank}/` -> ex: `/ergast/f1/fastest/2/qualifying/`
+
+**Example**: If you do `/ergast/f1/2024/17/fastest/1/qualifying/` it will return Lando Norris' qualifying result for the 2024 Azerbaijan Grand Prix as he had the fastest lap in the race, even though he qualified 16th.
+
+---
+
+### status
+
+**Filters for the qualifying results of any drivers with the finishing statusId at a given Grand Prix**
+
+`/status/{statusId}/` -> ex: `/ergast/f1/status/11/qualifying/`
+
+---
+
+## Success Response
+
+**Code** : `200 OK`
+
+**Response Fields** :
+
+[Common Response Fields](./README.md#common-response-fields)
+
+`MRData.RaceTable` : The object containing the list of the all races and associated filters.
+
+`MRData.RaceTable.Races` : The list of all races returned.
+
+`MRData.RaceTable.Races[i]` : A given race object.
+
+`MRData.RaceTable.Races[i].QualifyingResults` : The list of qualifying results for the given race.
+
+`MRData.RaceTable.Races[i].QualifyingResults[i]` : A given qualifying result object.
+
+---
+
+## Qualifying Result Object Fields:
+
+|Field|Always Included|Description|type
+|---|:---:|---|---|
+|number|✅|Driver's car number|String
+|position|✅|Qualifying Result Position|String
+|Driver|✅|Driver information (driverId, permanentNumber, code, url, givenName, familyName, dateOfBirth, nationality)|Object
+|Constructor|✅|Constructor information (constructorId, url, name, nationality)|Object
+|Q1|🟡|Qualifying 1 Result (mm:ss.sss)|String
+|Q2|🟡|Qualifying 2 Result (mm:ss.sss)|String
+|Q3|🟡|Qualifying 3 Result (mm:ss.sss)|String
+
+---
+
+## Examples:
+
+### Get list of all qualifying results in 2024
+
+`http://api.jolpi.ca/ergast/f1/2024/qualifying/`
+
+```json
+{
+  "MRData": {
+    "xmlns": "",
+    "series": "f1",
+    "url": "http://api.jolpi.ca/ergast/f1/2024/qualifying/",
+    "limit": "30",
+    "offset": "0",
+    "total": "359",
+    "RaceTable": {
+      "season": "2024",
+      "Races": [
+        {
+          "season": "2024",
+          "round": "1",
+          "url": "https://en.wikipedia.org/wiki/2024_Bahrain_Grand_Prix",
+          "raceName": "Bahrain Grand Prix",
+          "Circuit": {
+            "circuitId": "bahrain",
+            "url": "http://en.wikipedia.org/wiki/Bahrain_International_Circuit",
+            "circuitName": "Bahrain International Circuit",
+            "Location": {
+              "lat": "26.0325",
+              "long": "50.5106",
+              "locality": "Sakhir",
+              "country": "Bahrain"
+            }
+          },
+          "date": "2024-03-02",
+          "time": "15:00:00Z",
+          "QualifyingResults": [
+            {
+              "number": "1",
+              "position": "1",
+              "Driver": {
+                "driverId": "max_verstappen",
+                "permanentNumber": "33",
+                "code": "VER",
+                "url": "http://en.wikipedia.org/wiki/Max_Verstappen",
+                "givenName": "Max",
+                "familyName": "Verstappen",
+                "dateOfBirth": "1997-09-30",
+                "nationality": "Dutch"
+              },
+              "Constructor": {
+                "constructorId": "red_bull",
+                "url": "http://en.wikipedia.org/wiki/Red_Bull_Racing",
+                "name": "Red Bull",
+                "nationality": "Austrian"
+              },
+              "Q1": "1:30.031",
+              "Q2": "1:29.374",
+              "Q3": "1:29.179"
+            },
+            {
+              "number": "16",
+              "position": "2",
+              "Driver": {
+                "driverId": "leclerc",
+                "permanentNumber": "16",
+                "code": "LEC",
+                "url": "http://en.wikipedia.org/wiki/Charles_Leclerc",
+                "givenName": "Charles",
+                "familyName": "Leclerc",
+                "dateOfBirth": "1997-10-16",
+                "nationality": "Monegasque"
+              },
+              "Constructor": {
+                "constructorId": "ferrari",
+                "url": "http://en.wikipedia.org/wiki/Scuderia_Ferrari",
+                "name": "Ferrari",
+                "nationality": "Italian"
+              },
+              "Q1": "1:30.243",
+              "Q2": "1:29.165",
+              "Q3": "1:29.407"
+            },
+            ...more
+          ]
+        }
+      ]
+    }
+  }
+}
+```
+
+### Get the qualifying results from the 17th Round of the 2024 season.
+
+`http://api.jolpi.ca/ergast/f1/2024/17/qualifying/`
+
+```json
+{
+  "MRData": {
+    "xmlns": "",
+    "series": "f1",
+    "url": "http://api.jolpi.ca/ergast/f1/2024/17/qualifying/",
+    "limit": "30",
+    "offset": "0",
+    "total": "20",
+    "RaceTable": {
+      "season": "2024",
+      "round": "17",
+      "Races": [
+        {
+          "season": "2024",
+          "round": "17",
+          "url": "https://en.wikipedia.org/wiki/2024_Azerbaijan_Grand_Prix",
+          "raceName": "Azerbaijan Grand Prix",
+          "Circuit": {
+            "circuitId": "baku",
+            "url": "http://en.wikipedia.org/wiki/Baku_City_Circuit",
+            "circuitName": "Baku City Circuit",
+            "Location": {
+              "lat": "40.3725",
+              "long": "49.8533",
+              "locality": "Baku",
+              "country": "Azerbaijan"
+            }
+          },
+          "date": "2024-09-15",
+          "time": "11:00:00Z",
+          "QualifyingResults": [
+            {
+              "number": "16",
+              "position": "1",
+              "Driver": {
+                "driverId": "leclerc",
+                "permanentNumber": "16",
+                "code": "LEC",
+                "url": "http://en.wikipedia.org/wiki/Charles_Leclerc",
+                "givenName": "Charles",
+                "familyName": "Leclerc",
+                "dateOfBirth": "1997-10-16",
+                "nationality": "Monegasque"
+              },
+              "Constructor": {
+                "constructorId": "ferrari",
+                "url": "http://en.wikipedia.org/wiki/Scuderia_Ferrari",
+                "name": "Ferrari",
+                "nationality": "Italian"
+              },
+              "Q1": "1:42.775",
+              "Q2": "1:42.056",
+              "Q3": "1:41.365"
+            },
+            {
+              "number": "81",
+              "position": "2",
+              "Driver": {
+                "driverId": "piastri",
+                "permanentNumber": "81",
+                "code": "PIA",
+                "url": "http://en.wikipedia.org/wiki/Oscar_Piastri",
+                "givenName": "Oscar",
+                "familyName": "Piastri",
+                "dateOfBirth": "2001-04-06",
+                "nationality": "Australian"
+              },
+              "Constructor": {
+                "constructorId": "mclaren",
+                "url": "http://en.wikipedia.org/wiki/McLaren",
+                "name": "McLaren",
+                "nationality": "British"
+              },
+              "Q1": "1:43.033",
+              "Q2": "1:42.598",
+              "Q3": "1:41.686"
+            },
+            ...more
+          ]
+        }
+      ]
+    }
+  }
+}
+```

--- a/docs/endpoints/races.md
+++ b/docs/endpoints/races.md
@@ -21,6 +21,16 @@ Gets list of races
 
 ---
 
+### Round
+
+**Filters for the race for a specified round in a specific season. Round numbers 1 -> n races are valid as well as 'last' and 'next'**
+
+`/{season}/{roundNumber}/` -> ex: `/ergast/f1/2024/5/races/`
+
+**Note**: To utilize the `round` parameter it must be combined with a season filter and needs to be the first route after `/ergast/f1/{season}/`
+
+---
+
 ### circuits
 
 **Filters for only races featuring a specified circuit**

--- a/docs/endpoints/races.md
+++ b/docs/endpoints/races.md
@@ -1,7 +1,7 @@
 [← Documentation Home](/docs/README.md)
 # Races
 
-Gets list of races 
+Gets list of races from earliest to latest.
 
 **URL** : `/ergast/f1/races/`
 

--- a/docs/endpoints/races.md
+++ b/docs/endpoints/races.md
@@ -3,7 +3,7 @@
 
 Gets list of races 
 
-**URL** : `/ergast/f1/races`
+**URL** : `/ergast/f1/races/`
 
 [Available Query Parameters](./README.md#query-parameters)
 
@@ -15,7 +15,7 @@ Gets list of races
 
 **Filters for races only from a specified season. Year numbers are valid as is 'current' to get the current season**
 
-`/{season}/` -> ex: `/ergast/f1/2024/races`
+`/{season}/` -> ex: `/ergast/f1/2024/races/`
 
 **Note**: To utilize the `season` parameter it needs to be the first route after `/ergast/f1/`
 
@@ -25,7 +25,7 @@ Gets list of races
 
 **Filters for only races featuring a specified circuit**
 
-`/circuits/{circuitId}/` -> ex: `/ergast/f1/circuits/monza/races`
+`/circuits/{circuitId}/` -> ex: `/ergast/f1/circuits/monza/races/`
 
 ---
 
@@ -33,7 +33,7 @@ Gets list of races
 
 **Filters for only races featuring a specified constructor**
 
-`/constructors/{constructorId}/` -> ex: `/ergast/f1/constructors/williams/races`
+`/constructors/{constructorId}/` -> ex: `/ergast/f1/constructors/williams/races/`
 
 ---
 
@@ -41,7 +41,7 @@ Gets list of races
 
 **Filters for only races featuring a specified driver**
 
-`/drivers/{driverId}/` -> ex: `/ergast/f1/drivers/hamilton/races`
+`/drivers/{driverId}/` -> ex: `/ergast/f1/drivers/hamilton/races/`
 
 
 ---
@@ -50,7 +50,7 @@ Gets list of races
 
 **Filters for only races featuring a specified grid position**
 
-`/grid/{gridPosition}/` -> ex: `/ergast/f1/grid/27/races`
+`/grid/{gridPosition}/` -> ex: `/ergast/f1/grid/27/races/`
 
 ---
 
@@ -58,7 +58,7 @@ Gets list of races
 
 **Filters for only races featuring a specified finishing status of a driver**
 
-`/status/{statusId}/` -> ex: `/ergast/f1/status/2/races`
+`/status/{statusId}/` -> ex: `/ergast/f1/status/2/races/`
 
 ---
 
@@ -102,7 +102,7 @@ Gets list of races
 
 ### Get list of races in F1 history
 
-`https://api.jolpi.ca/ergast/f1/races/`
+`https://api.jolpi.ca/ergast/f1/races//`
 
 ```json
 {
@@ -160,7 +160,7 @@ Gets list of races
 
 ### Get all races of a specific season (2024) and associated information
 
-`https://api.jolpi.ca/ergast/f1/2024/races`
+`https://api.jolpi.ca/ergast/f1/2024/races/`
 
 ```json
 {

--- a/docs/endpoints/races.md
+++ b/docs/endpoints/races.md
@@ -1,7 +1,7 @@
 [← Documentation Home](/docs/README.md)
 # Races
 
-Gets list of races from earliest to latest.
+Returns list of races from earliest to latest.
 
 **URL** : `/ergast/f1/races/`
 
@@ -9,31 +9,31 @@ Gets list of races from earliest to latest.
 
 ---
 
-## Route Parameters:
+## Route Parameters
 
 ### Season
 
-**Filters for races only from a specified season. Year numbers are valid as is `current` to get the current season**
+Filters for races only from a specified season. Year numbers are valid as is `current` to get the current season.
 
 `/{season}/` -> ex: `/ergast/f1/2024/races/`
 
-**Note**: To utilize the `season` parameter it needs to be the first route after `/ergast/f1/`
+**Note**: To utilize the `season` parameter, it needs to be the first argument after `/ergast/f1/`.
 
 ---
 
 ### Round
 
-**Filters for the race for a specified round in a specific season. Round numbers 1 -> n races are valid as well as `last` and `next`**
+Filters for the race for a specified round in a specific season. Round numbers 1 -> `n` races are valid as well as `last` and `next`.
 
 `/{season}/{round}/` -> ex: `/ergast/f1/2024/5/races/`
 
-**Note**: To utilize the `round` parameter it must be combined with a season filter and needs to be the first route after `/ergast/f1/{season}/`
+**Note**: To utilize the `round` parameter it must be combined with a season filter and needs to be the first argument after `/ergast/f1/{season}/`.
 
 ---
 
 ### circuits
 
-**Filters for only races featuring a specified circuit**
+Filters for only races featuring a specified circuit.
 
 `/circuits/{circuitId}/` -> ex: `/ergast/f1/circuits/monza/races/`
 
@@ -41,7 +41,7 @@ Gets list of races from earliest to latest.
 
 ### constructors
 
-**Filters for only races featuring a specified constructor**
+Filters for only races featuring a specified constructor.
 
 `/constructors/{constructorId}/` -> ex: `/ergast/f1/constructors/williams/races/`
 
@@ -49,7 +49,7 @@ Gets list of races from earliest to latest.
 
 ### drivers
 
-**Filters for only races featuring a specified driver**
+Filters for only races featuring a specified driver.
 
 `/drivers/{driverId}/` -> ex: `/ergast/f1/drivers/hamilton/races/`
 
@@ -58,7 +58,7 @@ Gets list of races from earliest to latest.
 
 ### grid
 
-**Filters for only races featuring a specified grid position**
+Filters for only races featuring a specified grid position.
 
 `/grid/{gridPosition}/` -> ex: `/ergast/f1/grid/27/races/`
 
@@ -66,7 +66,7 @@ Gets list of races from earliest to latest.
 
 ### status
 
-**Filters for only races featuring a specified finishing status of a driver**
+Filters for only races featuring a specified finishing status of a driver.
 
 `/status/{statusId}/` -> ex: `/ergast/f1/status/2/races/`
 
@@ -84,7 +84,7 @@ Gets list of races from earliest to latest.
 
 `MRData.RaceTable.Races` : The list of all races returned.
 
-`MRData.RaceTable.Races[i]` : A given race object
+`MRData.RaceTable.Races[i]` : A given race object.
 
 ---
 
@@ -112,7 +112,7 @@ Gets list of races from earliest to latest.
 
 ### Get list of races in F1 history
 
-`https://api.jolpi.ca/ergast/f1/races//`
+`https://api.jolpi.ca/ergast/f1/races/`
 
 ```json
 {

--- a/docs/endpoints/races.md
+++ b/docs/endpoints/races.md
@@ -98,13 +98,13 @@ Gets list of races from earliest to latest.
 |raceName|✅|
 |Circuit|✅|
 |date|✅|
-|time|❌|
-|FirstPractice|❌|
-|SecondPractice|❌|
-|ThirdPractice|❌|
-|Qualifying|❌|
-|Sprint|❌|
-|SprintQualifying|❌|
+|time|🟡|
+|FirstPractice|🟡|
+|SecondPractice|🟡|
+|ThirdPractice|🟡|
+|Qualifying|🟡|
+|Sprint|🟡|
+|SprintQualifying|🟡|
 
 ---
 

--- a/docs/endpoints/races.md
+++ b/docs/endpoints/races.md
@@ -5,7 +5,7 @@ Gets list of races from earliest to latest.
 
 **URL** : `/ergast/f1/races/`
 
-[Available Query Parameters](./README.md#query-parameters)
+[Available Query Parameters](docs/README.md#query-parameters)
 
 ---
 

--- a/docs/endpoints/races.md
+++ b/docs/endpoints/races.md
@@ -90,21 +90,21 @@ Gets list of races from earliest to latest.
 
 ## Race Object Fields:
 
-|Field|Always Included|
-|---|:---:|
-|season| ✅ |
-|round|✅|
-|url|✅|
-|raceName|✅|
-|Circuit|✅|
-|date|✅|
-|time|🟡|
-|FirstPractice|🟡|
-|SecondPractice|🟡|
-|ThirdPractice|🟡|
-|Qualifying|🟡|
-|Sprint|🟡|
-|SprintQualifying|🟡|
+|Field|Always Included|Description|type
+|---|:---:|---|---|
+|season|✅|Season year|String
+|round|✅|Round Number|String
+|url|✅|Wikipedia URL of race|String
+|raceName|✅|Name of the race|String
+|Circuit|✅|Circuit information (circuitId, url, circuitName, Location)|Object
+|date|✅|Date of the race (YYYY-MM-DD)|String
+|time|🟡|UTC start time of the race|String
+|FirstPractice|🟡|First Practice (date, time)|Object
+|SecondPractice|🟡|Second Practice (date, time)|Object
+|ThirdPractice|🟡|Third Practice (date, time)|Object
+|Qualifying|🟡|Qualifying (date, time)|Object
+|Sprint|🟡|Sprint Race (date, time)|Object
+|SprintQualifying|🟡|Sprint Qualifying (date, time)|Object
 
 ---
 

--- a/docs/endpoints/races.md
+++ b/docs/endpoints/races.md
@@ -5,7 +5,7 @@ Gets list of races from earliest to latest.
 
 **URL** : `/ergast/f1/races/`
 
-[Available Query Parameters](docs/README.md#query-parameters)
+[Available Query Parameters](/docs/README.md#query-parameters)
 
 ---
 

--- a/docs/endpoints/races.md
+++ b/docs/endpoints/races.md
@@ -1,7 +1,7 @@
 [← Documentation Home](/docs/README.md)
 # Races
 
-Returns list of races from earliest to latest.
+Returns a list of races from earliest to latest.
 
 **URL** : `/ergast/f1/races/`
 

--- a/docs/endpoints/races.md
+++ b/docs/endpoints/races.md
@@ -104,7 +104,7 @@ Filters for only races featuring a specified finishing status of a driver.
 |ThirdPractice|🟡|Third Practice (date, time)|Object
 |Qualifying|🟡|Qualifying (date, time)|Object
 |Sprint|🟡|Sprint Race (date, time)|Object
-|SprintQualifying|🟡|Sprint Qualifying (date, time)|Object
+|SprintQualifying / SprintShootout|🟡| Shootouts took place in 2023, otherwise they are Qualifying (date, time)|Object
 
 ---
 

--- a/docs/endpoints/races.md
+++ b/docs/endpoints/races.md
@@ -13,7 +13,7 @@ Gets list of races
 
 ### Season
 
-**Filters for races only from a specified season. Year numbers are valid as is 'current' to get the current season**
+**Filters for races only from a specified season. Year numbers are valid as is `current` to get the current season**
 
 `/{season}/` -> ex: `/ergast/f1/2024/races/`
 
@@ -23,7 +23,7 @@ Gets list of races
 
 ### Round
 
-**Filters for the race for a specified round in a specific season. Round numbers 1 -> n races are valid as well as 'last' and 'next'**
+**Filters for the race for a specified round in a specific season. Round numbers 1 -> n races are valid as well as `last` and `next`**
 
 `/{season}/{roundNumber}/` -> ex: `/ergast/f1/2024/5/races/`
 

--- a/docs/endpoints/races.md
+++ b/docs/endpoints/races.md
@@ -90,7 +90,7 @@ Gets list of races from earliest to latest.
 
 ## Race Object Fields:
 
-|Field|Required|
+|Field|Always Included|
 |---|:---:|
 |season| ✅ |
 |round|✅|

--- a/docs/endpoints/races.md
+++ b/docs/endpoints/races.md
@@ -25,7 +25,7 @@ Gets list of races
 
 **Filters for the race for a specified round in a specific season. Round numbers 1 -> n races are valid as well as `last` and `next`**
 
-`/{season}/{roundNumber}/` -> ex: `/ergast/f1/2024/5/races/`
+`/{season}/{round}/` -> ex: `/ergast/f1/2024/5/races/`
 
 **Note**: To utilize the `round` parameter it must be combined with a season filter and needs to be the first route after `/ergast/f1/{season}/`
 

--- a/docs/endpoints/seasons.md
+++ b/docs/endpoints/seasons.md
@@ -1,7 +1,7 @@
 [← Documentation Home](/docs/README.md)
 # Seasons
 
-Returns list of seasons from earliest to latest.
+Returns a list of seasons from earliest to latest.
 
 **URL** : `/ergast/f1/seasons/`
 

--- a/docs/endpoints/seasons.md
+++ b/docs/endpoints/seasons.md
@@ -5,7 +5,7 @@ Gets list of seasons from earliest to latest.
 
 **URL** : `/ergast/f1/seasons/`
 
-[Available Query Parameters](./README.md#query-parameters)
+[Available Query Parameters](docs/README.md#query-parameters)
 
 ---
 

--- a/docs/endpoints/seasons.md
+++ b/docs/endpoints/seasons.md
@@ -80,10 +80,10 @@ Gets list of seasons from earliest to latest.
 
 ## Season Object Fields:
 
-|Field|Always Included|
-|---|:---:|
-|season|✅|
-|url|✅|
+|Field|Always Included|Description|type
+|---|:---:|---|---|
+|season|✅|Season year|String
+|url|✅|Wikipedia URL of the season|String
 
 ---
 

--- a/docs/endpoints/seasons.md
+++ b/docs/endpoints/seasons.md
@@ -13,7 +13,7 @@ Gets list of seasons
 
 ### Season
 
-**Filters for a specified season. Year numbers are valid as is 'current' to get the current season**
+**Filters for a specified season. Year numbers are valid as is `current` to get the current season**
 
 `/{season}/` -> ex: `/ergast/f1/2024/seasons/`
 

--- a/docs/endpoints/seasons.md
+++ b/docs/endpoints/seasons.md
@@ -80,7 +80,7 @@ Gets list of seasons from earliest to latest.
 
 ## Season Object Fields:
 
-|Field|Required|
+|Field|Always Included|
 |---|:---:|
 |season|✅|
 |url|✅|

--- a/docs/endpoints/seasons.md
+++ b/docs/endpoints/seasons.md
@@ -1,7 +1,7 @@
 [← Documentation Home](/docs/README.md)
 # Seasons
 
-Gets list of seasons from earliest to latest.
+Returns list of seasons from earliest to latest.
 
 **URL** : `/ergast/f1/seasons/`
 
@@ -9,21 +9,21 @@ Gets list of seasons from earliest to latest.
 
 ---
 
-## Route Parameters:
+## Route Parameters
 
 ### Season
 
-**Filters for a specified season. Year numbers are valid as is `current` to get the current season**
+Filters for a specified season. Year numbers are valid as is `current` to get the current season.
 
 `/{season}/` -> ex: `/ergast/f1/2024/seasons/`
 
-**Note**: To utilize the `season` parameter it needs to be the first route after `/ergast/f1/`
+**Note**: To utilize the `season` parameter, it needs to be the first argument after `/ergast/f1/`.
 
 ---
 
 ### circuits
 
-**Filters for only seasons featuring a specified circuit**
+Filters for only seasons featuring a specified circuit.
 
 `/circuits/{circuitId}/` -> ex: `/ergast/f1/circuits/monza/seasons/`
 
@@ -31,7 +31,7 @@ Gets list of seasons from earliest to latest.
 
 ### constructors
 
-**Filters for only seasons featuring a specified constructor**
+Filters for only seasons featuring a specified constructor.
 
 `/constructors/{constructorId}/` -> ex: `/ergast/f1/constructors/williams/seasons/`
 
@@ -39,7 +39,7 @@ Gets list of seasons from earliest to latest.
 
 ### drivers
 
-**Filters for only seasons featuring a specified driver**
+Filters for only seasons featuring a specified driver.
 
 `/drivers/{driverId}/` -> ex: `/ergast/f1/drivers/hamilton/seasons/`
 
@@ -48,7 +48,7 @@ Gets list of seasons from earliest to latest.
 
 ### grid
 
-**Filters for only seasons featuring a specified grid position**
+Filters for only seasons featuring a specified grid position.
 
 `/grid/{gridPosition}/` -> ex: `/ergast/f1/grid/27/seasons/`
 
@@ -56,7 +56,7 @@ Gets list of seasons from earliest to latest.
 
 ### status
 
-**Filters for only seasons featuring a specified finishing status of a driver in at least one race that season**
+Filters for only seasons featuring a specified finishing status of a driver in at least one race that season.
 
 `/status/{statusId}/` -> ex: `/ergast/f1/status/2/seasons/`
 
@@ -74,7 +74,7 @@ Gets list of seasons from earliest to latest.
 
 `MRData.SeasonTable.Seasons` : The list of all seasons returned.
 
-`MRData.SeasonTable.Seasons[i]` : A given season object
+`MRData.SeasonTable.Seasons[i]` : A given season object.
 
 ---
 

--- a/docs/endpoints/seasons.md
+++ b/docs/endpoints/seasons.md
@@ -1,7 +1,7 @@
 [← Documentation Home](/docs/README.md)
 # Seasons
 
-Gets list of seasons 
+Gets list of seasons from earliest to latest.
 
 **URL** : `/ergast/f1/seasons/`
 

--- a/docs/endpoints/seasons.md
+++ b/docs/endpoints/seasons.md
@@ -3,7 +3,7 @@
 
 Gets list of seasons 
 
-**URL** : `/ergast/f1/seasons`
+**URL** : `/ergast/f1/seasons/`
 
 [Available Query Parameters](./README.md#query-parameters)
 
@@ -15,7 +15,7 @@ Gets list of seasons
 
 **Filters for a specified season. Year numbers are valid as is 'current' to get the current season**
 
-`/{season}/` -> ex: `/ergast/f1/2024/seasons`
+`/{season}/` -> ex: `/ergast/f1/2024/seasons/`
 
 **Note**: To utilize the `season` parameter it needs to be the first route after `/ergast/f1/`
 
@@ -25,7 +25,7 @@ Gets list of seasons
 
 **Filters for only seasons featuring a specified circuit**
 
-`/circuits/{circuitId}/` -> ex: `/ergast/f1/circuits/monza/seasons`
+`/circuits/{circuitId}/` -> ex: `/ergast/f1/circuits/monza/seasons/`
 
 ---
 
@@ -33,7 +33,7 @@ Gets list of seasons
 
 **Filters for only seasons featuring a specified constructor**
 
-`/constructors/{constructorId}/` -> ex: `/ergast/f1/constructors/williams/seasons`
+`/constructors/{constructorId}/` -> ex: `/ergast/f1/constructors/williams/seasons/`
 
 ---
 
@@ -41,7 +41,7 @@ Gets list of seasons
 
 **Filters for only seasons featuring a specified driver**
 
-`/drivers/{driverId}/` -> ex: `/ergast/f1/drivers/hamilton/seasons`
+`/drivers/{driverId}/` -> ex: `/ergast/f1/drivers/hamilton/seasons/`
 
 
 ---
@@ -50,7 +50,7 @@ Gets list of seasons
 
 **Filters for only seasons featuring a specified grid position**
 
-`/grid/{gridPosition}/` -> ex: `/ergast/f1/grid/27/seasons`
+`/grid/{gridPosition}/` -> ex: `/ergast/f1/grid/27/seasons/`
 
 ---
 
@@ -58,7 +58,7 @@ Gets list of seasons
 
 **Filters for only seasons featuring a specified finishing status of a driver in at least one race that season**
 
-`/status/{statusId}/` -> ex: `/ergast/f1/status/2/seasons`
+`/status/{statusId}/` -> ex: `/ergast/f1/status/2/seasons/`
 
 ---
 
@@ -125,7 +125,7 @@ Gets list of seasons
 
 ### Get all seasons featuring a specific constructor (Alfa)
 
-`https://api.jolpi.ca/ergast/f1/constructors/alfa/seasons`
+`https://api.jolpi.ca/ergast/f1/constructors/alfa/seasons/`
 
 ```json
 {

--- a/docs/endpoints/seasons.md
+++ b/docs/endpoints/seasons.md
@@ -5,7 +5,7 @@ Gets list of seasons from earliest to latest.
 
 **URL** : `/ergast/f1/seasons/`
 
-[Available Query Parameters](docs/README.md#query-parameters)
+[Available Query Parameters](/docs/README.md#query-parameters)
 
 ---
 


### PR DESCRIPTION
## Why are you making this change?

To add documentation for the `/pitstops`, `/qualifying`, `/circuits`, `/constructors`, `/driverStandings`, and `/constructorStandings` endpoints  

## Contributing Checklist
- [ ] Unit tests for the changes are included in this PR.
- [x] I have read and agreed to the [contributing guidelines](CONTRIBUTING.md).
