### PR TITLE
Decouple status from Ergast, status endpoint ordered by count instead of id

### DIFF
--- a/docs/ergast_differences.md
+++ b/docs/ergast_differences.md
@@ -22,3 +22,6 @@ These issues are intentional and there are no plans to resolve them.
 - 2023: Ergast lists the Sprint Shootout as "SecondPractice", we have renamed this to "SprintShootout".
 - 2024 onwards: Ergast lists Sprint Qualifying as "SecondPractice", we have renamed this to "SprintQualifying".
 For more details on the returned values, refer to the [races endpoint](./endpoints/races.md).
+
+#### Status
+- Results are ordered by count instead of statusId. This allows our Database to be independant of Ergast.

--- a/jolpica_api/ergastapi/serializers.py
+++ b/jolpica_api/ergastapi/serializers.py
@@ -20,6 +20,8 @@ from jolpica.formula_one.models.managed_views import DriverChampionship, TeamCha
 from jolpica.formula_one.models.session import SessionStatus
 from jolpica.formula_one.utils import format_timedelta
 
+from .status_mapping import ERGAST_REVERSE_STATUS_MAPPING
+
 
 class ErgastModelSerializer(serializers.ModelSerializer):
     def to_representation(self, instance: Any) -> Any:
@@ -117,9 +119,12 @@ class RaceSerializer(BaseRaceSerializer):
 
 
 class StatusSerializer(ErgastModelSerializer):
-    statusId = serializers.CharField()  # noqa: N815
+    statusId = serializers.SerializerMethodField(method_name="get_status_id")  # noqa: N815
     status = serializers.CharField(source="detail")
     count = serializers.CharField()
+
+    def get_status_id(self, session_entry: dict) -> str:
+        return str(ERGAST_REVERSE_STATUS_MAPPING.get(session_entry["detail"], ""))
 
     class Meta:
         model = SessionEntry

--- a/jolpica_api/ergastapi/status_mapping.py
+++ b/jolpica_api/ergastapi/status_mapping.py
@@ -140,3 +140,5 @@ ERGAST_STATUS_MAPPING = {
     140: "Undertray",
     141: "Cooling system",
 }
+
+ERGAST_REVERSE_STATUS_MAPPING = {v: k for k, v in ERGAST_STATUS_MAPPING.items()}

--- a/jolpica_api/ergastapi/tests/test_views.py
+++ b/jolpica_api/ergastapi/tests/test_views.py
@@ -86,7 +86,7 @@ def test_viewsets(client: APIClient, endpoint: str, path: Path, django_assert_ma
     if re.search(r"(?i)status(?:/[0-9]+)?.json", endpoint):
         # Intentional Difference from Ergast, sort by count instead of statusId
         expected["MRData"]["StatusTable"]["Status"] = sorted(
-            expected["MRData"]["StatusTable"]["Status"], key=lambda x: (int(x["count"]), x["status"])
+            expected["MRData"]["StatusTable"]["Status"], key=lambda x: (-int(x["count"]), x["status"])
         )
 
     assert result == expected

--- a/jolpica_api/ergastapi/tests/test_views.py
+++ b/jolpica_api/ergastapi/tests/test_views.py
@@ -83,6 +83,12 @@ def test_viewsets(client: APIClient, endpoint: str, path: Path, django_assert_ma
                 race_data["SecondPractice"] = race_data["SprintQualifying"]
                 race_data.pop("SprintQualifying")
 
+    if re.search(r"(?i)status(?:/[0-9]+)?.json", endpoint):
+        # Intentional Difference from Ergast, sort by count instead of statusId
+        expected["MRData"]["StatusTable"]["Status"] = sorted(
+            expected["MRData"]["StatusTable"]["Status"], key=lambda x: (int(x["count"]), x["status"])
+        )
+
     assert result == expected
 
 

--- a/jolpica_api/ergastapi/views.py
+++ b/jolpica_api/ergastapi/views.py
@@ -254,7 +254,8 @@ class StatusViewSet(ErgastModelViewSet):
             .annotate(
                 count=Count("detail"),
             )
-            .order_by("count", "detail")
+            .filter(count__gt=0)
+            .order_by("-count", "detail")
             .distinct()
         )
 


### PR DESCRIPTION
## Why are you making this change?

- Previously the status endpoint was dependant on Ergast implementation details (The Primary key of each status), this PR removes that dependancy and uses a hardcoded map.
- Add status detail from status id to fix #168 

## Contributing Checklist
- [x] Unit tests for the changes are included in this PR.
- [x] I have read and agreed to the [contributing guidelines](https://github.com/jolpica/jolpica-f1/blob/main/CONTRIBUTING.md).
