### PR TITLE
added poetry shell plugin command to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,10 +29,9 @@ Current requirements are:
 - A postgres database which can be accessed via the `DATABASE_SECRET_URL` environment variable.
 
 ### Data Import
-- If not using the devcontainer, Install python dependencies `poetry install`, and activate the shell
+- If not using the devcontainer, Install python dependencies `poetry install`, and activate the environment
   ```
-  poetry self add poetry-plugin-shell
-  poetry shell
+  eval $(poetry env activate)
   ```
 - Run any initial setup for development
   ```

--- a/README.md
+++ b/README.md
@@ -29,7 +29,11 @@ Current requirements are:
 - A postgres database which can be accessed via the `DATABASE_SECRET_URL` environment variable.
 
 ### Data Import
-- If not using the devcontainer, Install python dependencies `poetry install`, and activate the venv `poetry shell`
+- If not using the devcontainer, Install python dependencies `poetry install`, and activate the shell
+  ```
+  poetry self add poetry-plugin-shell
+  poetry shell
+  ```
 - Run any initial setup for development
   ```
   make setup


### PR DESCRIPTION
## Why are you making this change?
addresses an issue where poetry's newest version requires the shell plugin to be manually added. [Closes #195 ](https://github.com/jolpica/jolpica-f1/issues/195)

## Contributing Checklist
- [x] Unit tests for the changes are included in this PR.
- [x] I have read and agreed to the [contributing guidelines](https://github.com/jolpica/jolpica-f1/blob/main/CONTRIBUTING.md).


fixes: #195 
