### PR TITLE
Fix missing link to endpoint docs and unclear sentence

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -11,7 +11,7 @@ jolpica-f1 is an open-source API for querying Formula 1 data. It is the successo
 ---
 
 ## Endpoints and Documentation:
-For any gaps found within our documentation, please check the Ergast docs [here](http://ergast.com/mrd/). 
+For any gaps found within our documentation, please check the Ergast docs [here](http://ergast.com/mrd/).
 
 | Endpoint                                              | Route |
 |-----                                                  |-----|
@@ -22,12 +22,12 @@ For any gaps found within our documentation, please check the Ergast docs [here]
 | [Driver Standings](/docs/endpoints/driverStandings.md)| `/ergast/f1/{season}/driverstandings/` |
 | [Laps](/docs/endpoints/laps.md)                       | `/ergast/f1/{season}/{round}/laps/` |
 | [Pitstops](/docs/endpoints/pitstops.md)               | `/ergast/f1/{season}/{round}/pitstops/` |
-| [Qualifying](/docs/endpoints/qualifying.md)              | `/ergast/f1/{season}/qualifying/` |
+| [Qualifying](/docs/endpoints/qualifying.md)           | `/ergast/f1/{season}/qualifying/` |
 | [Races](/docs/endpoints/races.md)                     | `/ergast/f1/races/` |
 | [Results](/docs/endpoints/results.md)                 | `/ergast/f1/results/` |
 | [Seasons](/docs/endpoints/seasons.md)                 | `/ergast/f1/seasons/` |
-| Sprint                                                | `/ergast/f1/sprint/` |
-| Status                                                |  `/ergast/f1/status/` |
+| [Sprint](/docs/endpoints/sprint.md)                   | `/ergast/f1/sprint/` |
+| [Status](/docs/endpoints/status.md)                   | `/ergast/f1/status/` |
 
 **Note**: All endpoints should either end with a `/` or `.json`
 

--- a/docs/endpoints/status.md
+++ b/docs/endpoints/status.md
@@ -7,7 +7,7 @@ Returns a list of finishing statuses and their counts across races matching the 
 
 In the future data returned by this endpoint, and the status field returned by other endpoints may be changed.
 
-Seasons prior to 2024 may have their corresponding status ids changed to match our updated enumeration of possible statuses ([see here](https://github.com/jolpica/jolpica-f1/blob/71f12b1c9637aa838926abcb6f4840fbfac4d87c/jolpica/formula_one/models/session.py#L64-L71)). It is recommended to rely only on `statusId` values other of: 1 (Finished), 2 (Disqualified), 3 (Accident), 31 (Retired), 143 (Lapped).
+Seasons prior to 2024 may have their corresponding status ids changed to match our updated enumeration of possible statuses ([see here](https://github.com/jolpica/jolpica-f1/blob/71f12b1c9637aa838926abcb6f4840fbfac4d87c/jolpica/formula_one/models/session.py#L64-L71)). It is recommended to rely only on the following `statusId` values: 1 (Finished), 2 (Disqualified), 3 (Accident), 31 (Retired), 143 (Lapped).
 
 Please note statusId 3, is currently not implemented for newer seasons, so some statuses that currently return 31 (Retired), may be updated to 3 (Accident) in the future.
 
@@ -93,7 +93,7 @@ Filters for only a specific status ID.
 
 `/status/{statusId}/` -> ex: `/ergast/f1/status/1/`
 
-**DISCLAIMER**: Seasons prior to 2024 may have their corresponding status ids changed to match our updated enumeration of possible statuses ([see here](https://github.com/jolpica/jolpica-f1/blob/71f12b1c9637aa838926abcb6f4840fbfac4d87c/jolpica/formula_one/models/session.py#L64-L71)). It is recommended to rely only on `statusId` values other of: 1 (Finished), 2 (Disqualified), 3 (Accident), 31 (Retired), 143 (Lapped).
+**DISCLAIMER**: Seasons prior to 2024 may have their corresponding status ids changed to match our updated enumeration of possible statuses ([see here](https://github.com/jolpica/jolpica-f1/blob/71f12b1c9637aa838926abcb6f4840fbfac4d87c/jolpica/formula_one/models/session.py#L64-L71)). It is recommended to rely only on the following `statusId` values: 1 (Finished), 2 (Disqualified), 3 (Accident), 31 (Retired), 143 (Lapped).
 
 Please note `statusId` 3, is currently not implemented for newer seasons, so some statuses that currently return 31 (Retired), may be updated to 3 (Accident) in the future.
 


### PR DESCRIPTION
## Why are you making this change?

- Links to the two new endpoint doc pages are missing on the documentation main page
- One sentence did not make sense, @jolpica how were you trying to word this yesterday?


## Contributing Checklist
- [ ] Unit tests for the changes are included in this PR.
- [x] I have read and agreed to the [contributing guidelines](https://github.com/jolpica/jolpica-f1/blob/main/CONTRIBUTING.md).
