### PR TITLE
Fix result time to leader display text when driver finished before the leader

### DIFF
--- a/jolpica_api/ergastapi/serializers.py
+++ b/jolpica_api/ergastapi/serializers.py
@@ -247,6 +247,9 @@ class ListResultsSerializer(serializers.ListSerializer):
         if finish_time == winner_time:
             # time = str(finish_time).strip(":0")
             time = str(finish_time)[:-3].lstrip("0:")
+        elif finish_time < winner_time:
+            # This can happen when the driver crashes, but is still classified
+            return ""
         else:
             time_diff = finish_time - winner_time
             time = f"+{format_timedelta(time_diff)}"


### PR DESCRIPTION
## Why are you making this change?
Sometimes a car can crash out but still be classified, resulting in a time before the lead car

## Contributing Checklist
- [x] Unit tests for the changes are included in this PR.
- [x] I have read and agreed to the [contributing guidelines](https://github.com/jolpica/jolpica-f1/blob/main/CONTRIBUTING.md).
