### PR TITLE
Added F1_CYD_Notifications to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,4 +47,4 @@ Below is a list of some open source community projects that use the jolpica-f1 A
 - [F1 Points Calculator](https://github.com/yuyangchee98/F1-Points-Calculator) - An interactive championship points calculator and race simulator for predicting F1 standings. Results update every week using jolpica-f1 data. 
 - [GridTip](https://github.com/selfire1/gridtip) - Website for social F1 tipping with your friends. Data is powered by the jolpica-f1 API.
 - [InkyCloud-F1](https://github.com/Rhiz3K/InkyCloud-F1) - E-Ink/ePaper F1 screen generator (1-bit BMP) showing next race info, full session times, and circuit details.
-- [F1_CYD_Notifications] (https://github.com/anthonyjclarke/F1_CYD_Notifications) - ESP32 Cheap Yellow Display (CYD) showing Formula 1 race information on TFT Display and WebUI.
+- [F1_CYD_Notifications](https://github.com/anthonyjclarke/F1_CYD_Notifications) - ESP32 Cheap Yellow Display (CYD) showing Formula 1 race information on TFT Display and WebUI.


### PR DESCRIPTION
## Why are you making this change?

This PR adds the F1_CYD_Notifications project to the README's Community Projects section. F1_CYD_Notifications runs on a "CYD" Colour Yellow Display ESP32 board and displays race infomation on the 320x240 Panel as well as a WebUI that uses the jolpica-f1 API.

Changes:

Added InkyCloud-F1 to the "Applications and Integrations" subsection of Community Projects

## Contributing Checklist
- [ ] Unit tests for the changes are included in this PR.
- [X] I have read and agreed to the [contributing guidelines](https://github.com/jolpica/jolpica-f1/blob/main/CONTRIBUTING.md).
