### PR TITLE
Added jolpica-go to Community Projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ Below is a list of some open source community projects that use the jolpica-f1 A
 - [FastF1](https://github.com/theOehrly/Fast-F1) - Python package for accessing and analyzing Formula 1 results, schedules, timing data and telemetry.
 - [f1dataR](https://github.com/SCasanova/f1dataR)-  R package to access Formula 1 Data from the jolpica-f1 API.
 - [JolpicaKit](https://github.com/fantasia-y/JolpicaKit) - Swift wrapper for the jolpica-f1 API.
+- [jolpica-go](https://github.com/kostplu/jolpica-go) - Go wrapper for the jolpica-f1 API.
 
 ### Applications and Integrations
 - [FormulaOne Card](https://github.com/marcokreeft87/formulaone-card) - Home Assistant Card showing Formula One Data.


### PR DESCRIPTION
## Why are you making this change?
This PR adds the jolpica-go project to the README's Community Projects section. It is a Go wrapper for the jolpica-f1 API.

## Contributing Checklist
- [ ] Unit tests for the changes are included in this PR.
- [x] I have read and agreed to the [contributing guidelines](https://github.com/jolpica/jolpica-f1/blob/main/CONTRIBUTING.md).
